### PR TITLE
Covariance in nestlc

### DIFF
--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -562,7 +562,7 @@ def nest_lc(data, model, param_names, bounds, guess_amplitude_bound=False,
         * ``bounds``: Dictionary of bounds on varied parameters (including
           any automatically determined bounds).
         * ``ndof``: Number of degrees of freedom.
-	* ``cov``: covariance of the varied parameters. 
+        * ``cov``: covariance of the varied parameters. 
     est_model : `~sncosmo.Model`
         Copy of model with parameters set to the values in ``res.param_dict``.
     """


### PR DESCRIPTION
Added changes to fitting.py:
- Added 'flatten_result' to _all_
- Changed the estimate of std (errors) in nest_lc() so that the estimate is unbiased
- Added res['cov'] which will hold the covariance of the varied parameters. 

Tests: 
- Compared standard deviation^2 to diagonal elements of the covariance matrix (exact match)
- Compared standard deviation after to standard deviation before (small changes, because these are different runs of nest_lc()? )
