### PR TITLE
Incorporated model covariance into nestlc function

### DIFF
--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -663,7 +663,7 @@ def nest_lc(data, model, param_names, bounds, guess_amplitude_bound=False,
     # Drop data that the model doesn't cover.
     data = cut_bands(data, model, z_bounds=bounds.get('z', None))
 
-    res = _nest_lc(data, model, param_names, modelcov=modelcov, bounds=bounds, 
+    res = _nest_lc(data, model, param_names, modelcov=modelcov, bounds=bounds,
                    priors=priors, nobj=nobj, maxiter=maxiter, verbose=verbose)
 
     res.bounds = bounds


### PR DESCRIPTION
Added modelcovariance to nested routines. I think two further changes should be done:
1. we should make modelcov=True the default
2. Routines like _chisq should not have a default value of modelcov, and should use the value of modelcov 
specified by the routines like chisq. Alternatively, if this is not convention we want to follow, I should change _nestlc. At least these should be consistent.
