### PR TITLE
changes to docstrings of models.py

### DIFF
--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -446,8 +446,8 @@ class TimeSeriesSource(Source):
     (amplitude) is the single free parameter of the model. It should be noted
     that while t and \lambda are in the rest frame of the object, the flux
     density is defined at redshift zero. This means that for objects with the
-    same intrinsic luminosity, the amplitude will be smaller for objects that
-    have higher redshift.
+    same intrinsic luminosity, the amplitude will be smaller for objects at
+     larger luminosity distances.
 
     Parameters
     ----------


### PR DESCRIPTION
amplitude parameter of `TimeSeriesModel` to be reflected in the
reference-api section.
