### PR TITLE
BUGFIX: SNANA VARNAMES / VARLIST (read_snana_ascii)

### DIFF
--- a/sncosmo/snanaio.py
+++ b/sncosmo/snanaio.py
@@ -223,7 +223,7 @@ def read_snana_ascii(fname, default_tablename=None):
 
         # If the word starts with 'VARNAMES', the following `nvar` words
         # define the column names of the table.
-        elif word.startswith('VARNAMES'):
+        elif word.startswith('VARNAMES') or word.startswith('VARLIST'):
 
             # Check that nvar is defined and that no column names are defined
             # for the current table.


### PR DESCRIPTION
The row in `SNANA`-formatted table files that indicates the names of columns can sometimes begin with the token `VARLIST` (not `VARNAMES`). `sncosmo` only checks for `VARNAMES`, causing it to die when it tries to read files that have the `VARLIST` token. This PR fixes this behavior by adding a `'VARLIST'` check on the same line as the `VARNAMES` check.
