### PR TITLE
Python 3 already!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,5 +116,5 @@ setup(name=PACKAGENAME,
           'Topic :: Scientific/Engineering :: Physics'],
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=True,
+      use_2to3=False,
       **package_info)

--- a/sncosmo/__init__.py
+++ b/sncosmo/__init__.py
@@ -157,9 +157,4 @@ if not _ASTROPY_SETUP_:
     from . import registry
     from . import _builtin
 
-    # For plotting we just don't include the functions
-    # if any of the matplotlib imports fail.
-    try:
-        from plotting import *
-    except ImportError:
-        pass
+    from .plotting import *

--- a/sncosmo/_builtin/__init__.py
+++ b/sncosmo/_builtin/__init__.py
@@ -1,3 +1,3 @@
-import bandpasses
-import sources
-import magsystems
+from . import bandpasses
+from . import sources
+from . import magsystems

--- a/sncosmo/_builtin/bandpasses.py
+++ b/sncosmo/_builtin/bandpasses.py
@@ -12,6 +12,7 @@ from astropy import units as u
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils import OrderedDict
 from astropy.config import ConfigurationItem
+from astropy.extern import six
 
 from .. import registry
 from ..spectral import Bandpass, read_bandpass
@@ -133,7 +134,7 @@ lines.extend([lines[1], ''])
 for refkey, ref in allrefs:
     lines.append('.. [{0}] {1}'.format(refkey, ref))
 lines.append('')
-for url, urlnum in urlnums.iteritems():
+for url, urlnum in six.iteritems(urlnums):
     lines.append('.. _`{0}`: {1}'.format(string.letters[urlnum], url))
 lines.append('')
 __doc__ = '\n'.join(lines)

--- a/sncosmo/_builtin/magsystems.py
+++ b/sncosmo/_builtin/magsystems.py
@@ -9,6 +9,7 @@ import string
 from astropy.io import fits
 from astropy.utils.data import download_file
 from astropy import units as u
+from astropy.extern import six
 
 from .. import registry
 from .. import Spectrum, MagSystem, SpectralMagSystem, ABMagSystem
@@ -83,7 +84,7 @@ for m in registry.get_loaders_metadata(MagSystem):
                  .format(m['name'], description, m['subclass'], urllink))
 
 lines.extend([lines[1], ''])
-for url, urlnum in urlnums.iteritems():
+for url, urlnum in six.iteritems(urlnums):
     lines.append('.. _`{0}`: {1}'.format(string.letters[urlnum], url))
 lines.append('')
 __doc__ = '\n'.join(lines)

--- a/sncosmo/_builtin/magsystems.py
+++ b/sncosmo/_builtin/magsystems.py
@@ -78,14 +78,14 @@ for m in registry.get_loaders_metadata(MagSystem):
                 urlnums[url] = 0
             else:
                 urlnums[url] = max(urlnums.values()) + 1
-        urllink = '`{0}`_'.format(string.letters[urlnums[url]])
+        urllink = '`{0}`_'.format(string.ascii_letters[urlnums[url]])
 
     lines.append("{0!r:10}  {1:60}  {2:35}  {3:15}"
                  .format(m['name'], description, m['subclass'], urllink))
 
 lines.extend([lines[1], ''])
 for url, urlnum in six.iteritems(urlnums):
-    lines.append('.. _`{0}`: {1}'.format(string.letters[urlnum], url))
+    lines.append('.. _`{0}`: {1}'.format(string.ascii_letters[urlnum], url))
 lines.append('')
 __doc__ = '\n'.join(lines)
 

--- a/sncosmo/_builtin/sources.py
+++ b/sncosmo/_builtin/sources.py
@@ -11,6 +11,7 @@ from astropy.io import fits
 from astropy import wcs
 from astropy.utils.data import (download_file, get_pkg_data_filename,
                                 get_readable_fileobj)
+from astropy.extern import six
 
 from .. import registry
 from .. import Source, TimeSeriesSource, SALT2Source
@@ -379,7 +380,7 @@ lines.extend([lines[1], ''])
 for refkey, ref in allrefs:
     lines.append('.. [{0}] `{1}`__'.format(refkey, ref))
 lines.append('')
-for url, urlnum in urlnums.iteritems():
+for url, urlnum in six.iteritems(urlnums):
     lines.append('.. _`{0}`: {1}'.format(string.letters[urlnum], url))
 lines.append('')
 for i, note in enumerate(allnotes):

--- a/sncosmo/_builtin/sources.py
+++ b/sncosmo/_builtin/sources.py
@@ -370,7 +370,7 @@ for m in registry.get_loaders_metadata(Source):
                 urlnums[url] = 0
             else:
                 urlnums[url] = max(urlnums.values()) + 1
-        urllink = '`{0}`_'.format(string.letters[urlnums[url]])
+        urllink = '`{0}`_'.format(string.ascii_letters[urlnums[url]])
 
     lines.append("{0!r:20}  {1!r:7}  {2:8}  {3:27}  {4:14}  {5:7}  {6:50}"
                  .format(m['name'], m['version'], m['type'], m['subclass'],
@@ -381,7 +381,7 @@ for refkey, ref in allrefs:
     lines.append('.. [{0}] `{1}`__'.format(refkey, ref))
 lines.append('')
 for url, urlnum in six.iteritems(urlnums):
-    lines.append('.. _`{0}`: {1}'.format(string.letters[urlnum], url))
+    lines.append('.. _`{0}`: {1}'.format(string.ascii_letters[urlnum], url))
 lines.append('')
 for i, note in enumerate(allnotes):
     lines.append('.. [{0}] {1}'.format(i + 1, note))

--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import division
+from __future__ import division, print_function
 from warnings import warn
 import copy
-from itertools import product
 
 import numpy as np
 from scipy.interpolate import InterpolatedUnivariateSpline as Spline1d
 from astropy.utils import OrderedDict as odict
+from astropy.extern import six
 
 from .photdata import standardize_data, normalize_data
 from . import nest
@@ -394,12 +394,13 @@ def fit_lc(data, model, param_names, bounds=None, method='minuit',
             kwargs['error_' + name] = step
 
         if verbose:
-            print "Initial parameters:"
+            print("Initial parameters:")
             for name in param_names:
-                print name, kwargs[name], 'step=', kwargs['error_' + name],
+                print(name, kwargs[name], 'step=', kwargs['error_' + name],
+                      end=" ")
                 if 'limit_' + name in kwargs:
-                    print 'bounds=', kwargs['limit_' + name],
-                print ''
+                    print('bounds=', kwargs['limit_' + name], end=" ")
+                print()
 
         m = iminuit.Minuit(fitchisq, errordef=1.,
                            forced_parameters=model.param_names,
@@ -513,7 +514,7 @@ def _nest_lc(data, model, param_names, modelcov,
 
     # Convert bounds/priors combinations into ppfs
     if bounds is not None:
-        for key, val in bounds.iteritems():
+        for key, val in six.iteritems(bounds):
             if key in ppfs:
                 continue  # ppfs take priority over bounds/priors
             a, b = val
@@ -803,6 +804,6 @@ def mcmc_lc(data, model, param_names, errors, bounds=None, nwalkers=10,
     # production run
     sampler.run_mcmc(pos, nsamples)
     if verbose:
-        print "Avg acceptance fraction:", np.mean(sampler.acceptance_fraction)
+        print("Avg acceptance fraction:", np.mean(sampler.acceptance_fraction))
 
     return sampler.flatchain

--- a/sncosmo/io.py
+++ b/sncosmo/io.py
@@ -12,6 +12,7 @@ from astropy.utils import OrderedDict as odict
 from astropy.table import Table
 from astropy.io import fits
 from astropy import wcs
+from astropy.extern import six
 
 from .photdata import dict_to_array
 
@@ -502,7 +503,7 @@ def _write_ascii(f, data, meta, **kwargs):
     metachar = kwargs.get('metachar', '@')
 
     if meta is not None:
-        for key, val in meta.iteritems():
+        for key, val in six.iteritems(meta):
             f.write('{0}{1}{2}{3}\n'.format(metachar, key, delim, str(val)))
 
     keys = data.dtype.names
@@ -540,7 +541,7 @@ def _write_salt2(f, data, meta, **kwargs):
     pedantic = kwargs.get('pedantic', True)
 
     if meta is not None:
-        for key, val in meta.iteritems():
+        for key, val in six.iteritems(meta):
             if not raw:
                 key = key.upper()
                 key = KEY_TO_SALT2KEY_META.get(key, key)
@@ -597,7 +598,7 @@ def _write_snana(f, data, meta, **kwargs):
     # Write metadata
     keys_as_written = []
     if meta is not None:
-        for key, val in meta.iteritems():
+        for key, val in six.iteritems(meta):
             if not raw:
                 key = key.upper()
                 key = KEY_TO_SNANAKEY_META.get(key, key)

--- a/sncosmo/io.py
+++ b/sncosmo/io.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Functions for supernova light curve I/O"""
 
+from __future__ import print_function
+
 from warnings import warn
 import os
 import sys
@@ -59,7 +61,7 @@ def read_griddata_ascii(name_or_obj):
         2-d array of shape (len(x0), len(x1)).
     """
 
-    if isinstance(name_or_obj, basestring):
+    if isinstance(name_or_obj, six.string_types):
         f = open(name_or_obj, 'rb')
     else:
         f = name_or_obj
@@ -158,7 +160,7 @@ def write_griddata_ascii(x0, x1, y, name_or_obj):
         Filename to write to or open file.
     """
 
-    if isinstance(name_or_obj, basestring):
+    if isinstance(name_or_obj, six.string_types):
         f = open(name_or_obj, 'rb')
     else:
         f = name_or_obj
@@ -167,7 +169,7 @@ def write_griddata_ascii(x0, x1, y, name_or_obj):
         for i in range(len(x1)):
             f.write("{0:.7g} {1:.7g} {2:.7g}\n".format(x0[j], x1[i], y[j, i]))
 
-    if isinstance(name_or_obj, basestring):
+    if isinstance(name_or_obj, six.string_types):
         f.close()
 
 
@@ -453,9 +455,10 @@ def read_lc(file_or_dir, format='ascii', **kwargs):
     Examples
     --------
 
-    Read an ascii format file that includes metadata:
+    Read an ascii format file that includes metadata (``StringIO``
+    behaves like a file object):
 
-    >>> from StringIO import StringIO  # StringIO behaves like a file object.
+    >>> from astropy.extern.six import StringIO
     >>> f = StringIO('''
     ... @id 1
     ... @RA 36.0
@@ -465,13 +468,14 @@ def read_lc(file_or_dir, format='ascii', **kwargs):
     ... 50000.1 r 2. 0.1 25. ab
     ... ''')
     >>> t = read_lc(f, format='ascii')
-    >>> print t
+    >>> print(t)
       time  band flux fluxerr  zp  zpsys
     ------- ---- ---- ------- ---- -----
     50000.0    g  1.0     0.1 25.0    ab
     50000.1    r  2.0     0.1 25.0    ab
     >>> t.meta
     OrderedDict([('id', 1), ('RA', 36.0), ('description', 'good')])
+
     """
 
     try:
@@ -482,8 +486,8 @@ def read_lc(file_or_dir, format='ascii', **kwargs):
 
     if format == 'salt2-old':
         meta, data = readfunc(file_or_dir, **kwargs)
-    elif isinstance(file_or_dir, basestring):
-        with open(file_or_dir, 'rb') as f:
+    elif isinstance(file_or_dir, six.string_types):
+        with open(file_or_dir, 'r') as f:
             meta, data = readfunc(f, **kwargs)
     else:
         meta, data = readfunc(file_or_dir, **kwargs)

--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -13,9 +13,8 @@ from scipy.interpolate import (InterpolatedUnivariateSpline as Spline1d,
                                RectBivariateSpline as Spline2d,
                                splmake, spleval)
 from astropy.utils import OrderedDict as odict
-from astropy import (cosmology,
-                     units as u,
-                     constants as const)
+from astropy import (cosmology, units as u, constants as const)
+from astropy.extern import six
 
 from .io import read_griddata_ascii
 from . import registry
@@ -381,7 +380,7 @@ class Source(_ModelBase):
         nsamples = int(ceil((self.maxphase()-self.minphase()) / sampling)) + 1
         phases = np.linspace(self.minphase(), self.maxphase(), nsamples)
 
-        if isinstance(band_or_wave, (basestring, Bandpass)):
+        if isinstance(band_or_wave, (six.string_types, Bandpass)):
             fluxes = self.bandflux(band_or_wave, phases)
         else:
             fluxes = self.flux(phases, band_or_wave)[:, 0]
@@ -608,7 +607,7 @@ class SALT2Source(Source):
         if modeldir is not None:
             for k in names_or_objs:
                 v = names_or_objs[k]
-                if (v is not None and isinstance(v, basestring)):
+                if (v is not None and isinstance(v, six.string_types)):
                     names_or_objs[k] = os.path.join(modeldir, v)
 
         # model components are interpolated to 2nd order
@@ -819,7 +818,7 @@ class SALT2Source(Source):
         self._V_WAVELENGTH = 5428.55
 
         # Read file
-        if isinstance(name_or_obj, basestring):
+        if isinstance(name_or_obj, six.string_types):
             f = open(name_or_obj, 'rb')
         else:
             f = name_or_obj

--- a/sncosmo/nest.py
+++ b/sncosmo/nest.py
@@ -2,6 +2,8 @@
 """Simple implementation of nested sampling routine to evaluate Bayesian
 evidence."""
 
+from __future__ import print_function
+
 import math
 import time
 from sys import stdout
@@ -212,10 +214,11 @@ def nest(loglikelihood, prior, npar, nipar, nobj=50, maxiter=10000,
     while it < maxiter and loglcalls < maxcall:
         if verbose:
             if logz > -1.e6:
-                print "\r{0} iter={1:6d} logz={2:8f}".format(verbose_name, it,
-                                                             logz),
+                print("\r{0} iter={1:6d} logz={2:8f}"
+                      .format(verbose_name, it, logz), end="")
             else:
-                print "\r{0} iter={1:6d} logz=".format(verbose_name, it),
+                print("\r{0} iter={1:6d} logz=".format(verbose_name, it),
+                      end="")
             stdout.flush()
 
         # worst object in collection and its weight (= width * likelihood)
@@ -277,7 +280,7 @@ def nest(loglikelihood, prior, npar, nipar, nobj=50, maxiter=10000,
 
     tottime = time.time() - time0
     if verbose:
-        print 'calls={0:d} time={1:7.3f}s'.format(loglcalls, tottime)
+        print('calls={0:d} time={1:7.3f}s'.format(loglcalls, tottime))
 
     # Add remaining objects.
     # After N samples have been taken out, the remaining width is e^(-N/nobj)

--- a/sncosmo/photdata.py
+++ b/sncosmo/photdata.py
@@ -3,9 +3,12 @@
 from __future__ import division
 
 import math
+
 import numpy as np
 from astropy.utils import OrderedDict as odict
 from astropy.table import Table
+from astropy.extern import six
+
 from .spectral import get_magsystem, get_bandpass
 
 _photdata_aliases = odict([
@@ -47,7 +50,8 @@ def dict_to_array(d):
         new_d[key] = np.atleast_1d(d[key])
 
     # Determine dtype of output array.
-    dtype = [(key, arr.dtype) for key, arr in new_d.iteritems()]
+    dtype = [(key, arr.dtype)
+             for key, arr in six.iteritems(new_d)]
 
     # Initialize ndarray and then fill it.
     col_len = max([len(v) for v in new_d.values()])

--- a/sncosmo/plotting.py
+++ b/sncosmo/plotting.py
@@ -6,10 +6,8 @@ import math
 
 import numpy as np
 from astropy.utils.misc import isiterable
-from matplotlib import cm
-from matplotlib import pyplot as plt
-from matplotlib.ticker import MaxNLocator, NullFormatter
-from mpl_toolkits.axes_grid1 import make_axes_locatable
+from astropy.extern import six
+from six.moves import range
 
 from .models import Source, Model, get_source
 from .spectral import get_bandpass, get_magsystem
@@ -19,8 +17,12 @@ from .utils import format_value
 __all__ = ['plot_lc', 'animate_source', 'animate_model']
 
 _model_ls = ['-', '--', ':', '-.']
-_cmap = cm.get_cmap('jet_r')
 _cmap_wavelims = (3000., 10000.)
+try:
+    from matplotlib import cm
+    _cmap = cm.get_cmap('jet_r')
+except:
+    pass
 
 
 def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab', pulls=True,
@@ -128,6 +130,11 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab', pulls=True,
 
     """
 
+    from matplotlib import pyplot as plt
+    from matplotlib.ticker import MaxNLocator, NullFormatter
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+
     if data is None and model is None:
         raise ValueError('must specify at least one of: data, model')
     if data is None and bands is None:
@@ -146,7 +153,7 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab', pulls=True,
     # Get the model labels
     if model_label is None:
         model_labels = [None] * len(models)
-    elif isinstance(model_label, basestring):
+    elif isinstance(model_label, six.string_types):
         model_labels = [model_label]
     else:
         model_labels = model_label
@@ -172,7 +179,7 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab', pulls=True,
         errors = {}
     if figtext is None:
         figtext = []
-    elif isinstance(figtext, basestring):
+    elif isinstance(figtext, six.string_types):
         figtext = [figtext]
     if len(models) == 1 and show_model_params:
         model = models[0]
@@ -256,7 +263,7 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab', pulls=True,
     bands = list(bands)
     waves = [get_bandpass(b).wave_eff for b in bands]
     waves_and_bands = sorted(zip(waves, bands))
-    for axnum in xrange(ncol * nrow):
+    for axnum in range(ncol * nrow):
         row = axnum // ncol
         col = axnum % ncol
         ax = axes[row, col]
@@ -462,17 +469,19 @@ def animate_source(source, label=None, fps=30, length=20.,
     ... # doctest: +SKIP
     >>> plt.show()                        # doctest: +SKIP
     """
+
+    from matplotlib import pyplot as plt
     from matplotlib import animation
 
     # Convert input to a list (if it isn't already).
-    if (not isiterable(source)) or isinstance(source, basestring):
+    if (not isiterable(source)) or isinstance(source, six.string_types):
         sources = [source]
     else:
         sources = source
 
     # Check that all entries are Source or strings.
     for m in sources:
-        if not (isinstance(m, basestring) or isinstance(m, Source)):
+        if not (isinstance(m, six.string_types) or isinstance(m, Source)):
             raise ValueError('str or Source instance expected for '
                              'source(s)')
     sources = [get_source(m) for m in sources]
@@ -480,7 +489,7 @@ def animate_source(source, label=None, fps=30, length=20.,
     # Get the source labels
     if label is None:
         labels = [None] * len(sources)
-    elif isinstance(label, basestring):
+    elif isinstance(label, six.string_types):
         labels = [label]
     else:
         labels = label

--- a/sncosmo/plotting.py
+++ b/sncosmo/plotting.py
@@ -134,7 +134,6 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab', pulls=True,
     from matplotlib.ticker import MaxNLocator, NullFormatter
     from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-
     if data is None and model is None:
         raise ValueError('must specify at least one of: data, model')
     if data is None and bands is None:

--- a/sncosmo/registry.py
+++ b/sncosmo/registry.py
@@ -3,6 +3,7 @@
 based on string identifiers."""
 
 from astropy.utils import OrderedDict
+from astropy.extern import six
 
 __all__ = ['register_loader', 'register', 'retrieve', 'get_loaders_metadata']
 
@@ -231,7 +232,7 @@ def get_loaders_metadata(data_class):
     """
 
     loaders_metadata = []
-    for lkey, loader in _loaders.iteritems():
+    for lkey, loader in six.iteritems(_loaders):
         if lkey[0] is not data_class:
             continue
         m = {'name': lkey[1]}

--- a/sncosmo/registry.py
+++ b/sncosmo/registry.py
@@ -87,7 +87,7 @@ def register(instance, name=None, data_class=None, force=False):
         except AttributeError:
             raise ValueError("name not given and instance has no 'name' "
                              "attribute")
-        if not isinstance(name, basestring):
+        if not isinstance(name, six.string_types):
             raise ValueError("name attribute of {0!r:s} is not a string.")
 
     if data_class is None:
@@ -187,7 +187,8 @@ def retrieve(data_class, name, version=None):
     if version is None:
         latest_version = None
         for regkey in _loaders.keys():
-            if (key == regkey[0:2] and regkey[2] > latest_version):
+            if (key == regkey[0:2] and (latest_version is None or
+                                        regkey[2] > latest_version)):
                 latest_version = regkey[2]
         if latest_version is not None:
             regkey = (key[0], key[1], latest_version)

--- a/sncosmo/simulation.py
+++ b/sncosmo/simulation.py
@@ -1,5 +1,7 @@
 """Tools for simulation of transients."""
 
+from __future__ import print_function
+
 import sys
 import math
 from copy import deepcopy
@@ -10,6 +12,7 @@ from scipy.interpolate import InterpolatedUnivariateSpline as Spline1d
 from astropy.table import Table
 from astropy.cosmology import FlatLambdaCDM
 from astropy.utils import OrderedDict as odict
+from astropy.extern.six.moves import range
 
 __all__ = ['zdist', 'realize_lcs']
 
@@ -49,7 +52,7 @@ def zdist(zmin, zmax, time=365.25, area=1.,
     Loop over the generator:
 
     >>> for z in zdist(0.0, 0.25):  # doctest: +SKIP
-    ...     print z                 # doctest: +SKIP
+    ...     print(z)                # doctest: +SKIP
     ...
     0.151285827576
     0.204078030595
@@ -87,7 +90,7 @@ def zdist(zmin, zmax, time=365.25, area=1.,
     # SN / (observer year) in shell
     shell_snrate = np.array([shell_vols[i] *
                              ratefunc(z_binctrs[i]) / (1.+z_binctrs[i])
-                             for i in xrange(z_bins)])
+                             for i in range(z_bins)])
 
     # SN / (observer year) within z_binedges
     vol_snrate = np.zeros_like(z_binedges)
@@ -101,7 +104,7 @@ def zdist(zmin, zmax, time=365.25, area=1.,
     # Total numbe of SNe to simulate.
     nsim = vol_snrate[-1] * (time/365.25) * (area/WHOLESKY_SQDEG)
 
-    for i in xrange(random.poisson(nsim)):
+    for i in range(random.poisson(nsim)):
         yield float(snrate_ppf(random.random()))
 
 

--- a/sncosmo/snanaio.py
+++ b/sncosmo/snanaio.py
@@ -1,7 +1,9 @@
 import numpy as np
+
 from astropy.utils import OrderedDict as odict
 from astropy.io import fits
 from astropy.table import Table, vstack
+from astropy.extern import six
 
 __all__ = ['read_snana_ascii', 'read_snana_fits', 'read_snana_simlib']
 
@@ -266,7 +268,7 @@ def read_snana_ascii(fname, default_tablename=None):
     # All values in each column are currently strings. Convert to int or
     # float if possible.
     for table in tables.values():
-        for colname, values in table.iteritems():
+        for colname, values in six.iteritems(table):
             try:
                 table[colname] = [int(val) for val in values]
             except ValueError:
@@ -308,7 +310,7 @@ def read_snana_ascii_multi(fnames, default_tablename=None):
         meta, tables = read_snana_ascii(fname,
                                         default_tablename=default_tablename)
 
-        for key, table in tables.iteritems():
+        for key, table in six.iteritems(tables):
             if key in alltables:
                 alltables[key].append(table)
             else:

--- a/sncosmo/snanaio.py
+++ b/sncosmo/snanaio.py
@@ -151,7 +151,7 @@ def read_snana_ascii(fname, default_tablename=None):
     Examples
     --------
 
-    >>> from StringIO import StringIO  # StringIO behaves like a file
+    >>> from astropy.extern.six import StringIO  # StringIO behaves like a file
     >>> f = StringIO('META1: a\\n'
     ...              'META2: 6\\n'
     ...              'NVAR_SN: 3\\n'
@@ -168,7 +168,7 @@ def read_snana_ascii(fname, default_tablename=None):
 
     The second is a dictionary of all the tables in the file:
 
-    >>> tables['SN']
+    >>> tables['SN']                                          # doctest: +SKIP
     <Table rows=2 names=('A','B','C')>
     array([(1, 2.0, 'x'), (4, 5.0, 'y')],
           dtype=[('A', '<i8'), ('B', '<f8'), ('C', 'S1')])
@@ -192,7 +192,7 @@ def read_snana_ascii(fname, default_tablename=None):
     meta = odict()  # initialize structure to hold metadata.
     tables = {}  # initialize structure to hold data.
 
-    if isinstance(fname, basestring):
+    if isinstance(fname, six.string_types):
         fh = open(fname, 'U')
     else:
         fh = fname

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -15,6 +15,7 @@ try:
 except:
     HAS_IMINUIT = False
 
+
 @pytest.mark.skipif(not HAS_IMINUIT, reason="no iminuit")
 class TestFitting:
     def setup_class(self):

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -2,15 +2,21 @@
 from __future__ import print_function
 
 
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
 from astropy.table import Table
 
 import sncosmo
 
+try:
+    import iminuit
+    HAS_IMINUIT = True
+except:
+    HAS_IMINUIT = False
 
+@pytest.mark.skipif(not HAS_IMINUIT, reason="no iminuit")
 class TestFitting:
-
     def setup_class(self):
         model = sncosmo.Model(source='hsiao-subsampled')
         params = {'t0': 56000., 'amplitude': 1.e-7, 'z': 0.1}

--- a/sncosmo/tests/test_models.py
+++ b/sncosmo/tests/test_models.py
@@ -1,9 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSES
 
-from cStringIO import StringIO
-
 import numpy as np
 from numpy.testing import assert_allclose, assert_approx_equal
+from astropy.extern import six
 
 import sncosmo
 from sncosmo import registry
@@ -65,7 +64,7 @@ class TestSALT2Source:
         # Create some 2-d grid files
         files = []
         for i in [0, 1]:
-            f = StringIO()
+            f = six.StringIO()
             sncosmo.write_griddata_ascii(phase, wave, vals, f)
             f.seek(0)  # return to start of file.
             files.append(f)
@@ -73,7 +72,7 @@ class TestSALT2Source:
         # CL file. The CL in magnitudes will be
         # CL(wave) = -(wave - B) / (V - B)  [B = 4302.57, V = 5428.55]
         # and transmission will be 10^(-0.4 * CL(wave))^c
-        clfile = StringIO()
+        clfile = six.StringIO()
         clfile.write("1\n"
                      "0.0\n"
                      "Salt2ExtinctionLaw.version 1\n"
@@ -83,13 +82,13 @@ class TestSALT2Source:
 
         # Create some more 2-d grid files
         for factor in [1., 0.01, 0.01, 0.01]:
-            f = StringIO()
+            f = six.StringIO()
             sncosmo.write_griddata_ascii(phase, wave, factor * vals, f)
             f.seek(0)  # return to start of file.
             files.append(f)
 
         # Create a 1-d grid file (color dispersion)
-        cdfile = StringIO()
+        cdfile = six.StringIO()
         for w in wave:
             cdfile.write("{0:f} {1:f}\n".format(w, 0.2))
         cdfile.seek(0)  # return to start of file.


### PR DESCRIPTION
This (finally) implements Python 3 support, using the six module. Currently, all tests pass on Py3 and Py2. However, I'm waiting on two things before merging this:

- iminuit (required for `fit_lc`) doesn't yet support python 3. Currently the `fit_lc` test is simply skipped if iminuit isn't installed. I'd like to get iminuit working on Py3 and ensure that fit_lc works.

- sncosmo still has only about 50% test coverage, so I'm worried that some untested things still don't work. Gotta up that test coverage first...