### PR TITLE
Data-fetching system refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ docs/api
 MANIFEST
 sncosmo/version.py
 sncosmo/cython_version.py
-sncosmo/sncosmo.cfg
 
 # emacs files
 *~

--- a/docs/_helpers/source_page.py
+++ b/docs/_helpers/source_page.py
@@ -10,8 +10,8 @@ from sncosmo import registry, Source
 
 lines = [
     '',
-    '  '.join([20*'=', 7*'=', 8*'=', 27*'=', 14*'=', 7*'=', 7*'=']),
-    '{0:20}  {1:7}  {2:8}  {3:27}  {4:14}  {5:7}  {6:50}'.format(
+    '  '.join([20*'=', 7*'=', 10*'=', 27*'=', 14*'=', 7*'=', 7*'=']),
+    '{0:20}  {1:7}  {2:10}  {3:27}  {4:14}  {5:7}  {6:50}'.format(
         'Name', 'Version', 'Type', 'Subclass', 'Reference', 'Website', 'Notes')
     ]
 lines.append(lines[1])
@@ -45,7 +45,7 @@ for m in registry.get_loaders_metadata(Source):
                 urlnums[url] = max(urlnums.values()) + 1
         urllink = '`{0}`_'.format(string.ascii_letters[urlnums[url]])
 
-    lines.append("{0!r:20}  {1!r:7}  {2:8}  {3:27}  {4:14}  {5:7}  {6:50}"
+    lines.append("{0!r:20}  {1!r:7}  {2:10}  {3:27}  {4:14}  {5:7}  {6:50}"
                  .format(m['name'], m['version'], m['type'], m['subclass'],
                          reflink, urllink, notelink))
 

--- a/sncosmo/__init__.py
+++ b/sncosmo/__init__.py
@@ -131,12 +131,14 @@ if not _ASTROPY_SETUP_:
         data_dir = ConfigItem(
             None,
             "Directory where sncosmo will store and read downloaded data "
-            "resources.",
+            "resources. If None, ASTROPY_CACHE_DIR/sncosmo is created and "
+            "used. Example: data_dir = /home/user/data/sncosmo",
             cfgtype='string(default=None)')
         sfd98_dir = ConfigItem(
             None,
             "Directory containing SFD (1998) dust maps, with names: "
-            "'SFD_dust_4096_ngp.fits' and 'SFD_dust_4096_sgp.fits'",
+            "'SFD_dust_4096_ngp.fits' and 'SFD_dust_4096_sgp.fits'. "
+            "Example: sfd98_dir = /home/user/data/sfd98",
             cfgtype='string(default=None)')
 
     # Create an instance of the class we just defined.

--- a/sncosmo/__init__.py
+++ b/sncosmo/__init__.py
@@ -125,9 +125,12 @@ if not _ASTROPY_SETUP_:
     # Create default configurations. The file sncosmo.cfg should be
     # kept in sync with the ConfigItems here.
     class Conf(ConfigNamespace):
-        """
-        Configuration parameters for sncosmo.
-        """
+        """Configuration parameters for sncosmo."""
+        data_dir = ConfigItem(
+            None,
+            "Directory where sncosmo will store and read downloaded data "
+            "resources.",
+            cfgtype='string(default=None)')
         sfd98_dir = ConfigItem(
             None,
             "Directory containing SFD (1998) dust maps, with names: "

--- a/sncosmo/__init__.py
+++ b/sncosmo/__init__.py
@@ -3,6 +3,8 @@
 sncosmo: A Python package for supernova cosmology
 """
 
+from __future__ import absolute_import
+
 # This indicates whether or not we are in the package's setup.py
 try:
     _ASTROPY_SETUP_
@@ -157,6 +159,7 @@ if not _ASTROPY_SETUP_:
     from .snanaio import *
     from .fitting import *
     from .simulation import *
-    from . import registry
-    from .builtins import *
     from .plotting import *
+    from . import registry
+
+    from .builtins import *

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -509,55 +509,55 @@ ref = ('SNANA', 'Kessler et al. 2009 '
        '<http://adsabs.harvard.edu/abs/2009PASP..121.1028K>')
 note = "extracted from SNANA's SNDATA_ROOT on 5 August 2014."
 
-# Two SDSS SNe do not have IAU IDs.
 # 'PSNID' denotes that model is used in PSNID.
-for name, sntype, fn in [('snana-2004fe', 'SN Ic', 'CSP-2004fe.SED'),
-                         ('snana-2004gq', 'SN Ic', 'CSP-2004gq.SED'),
-                         ('snana-sdss004012', 'SN Ic', 'SDSS-004012.SED'),
-                         ('snana-2006fo', 'SN Ic', 'SDSS-013195.SED'),  # PSNID
-                         ('snana-sdss014475', 'SN Ic', 'SDSS-014475.SED'),
-                         ('snana-2006lc', 'SN Ic', 'SDSS-015475.SED'),
-                         # 2007ms is type Ic in SNANA
-                         ('snana-2007ms', 'SN II-pec', 'SDSS-017548.SED'),
-                         ('snana-04D1la', 'SN Ic', 'SNLS-04D1la.SED'),
-                         ('snana-04D4jv', 'SN Ic', 'SNLS-04D4jv.SED'),
-                     ('snana-2004gv', 'SN Ib'),
-                     ('snana-2006ep', 'SN Ib'),
-                     ('snana-2007Y', 'SN Ib'),
-                     ('snana-2004ib', 'SN Ib'),   # sdss000020
-                     ('snana-2005hm', 'SN Ib'),   # sdss002744 PSNID
-                     ('snana-2006jo', 'SN Ib'),   # sdss014492 PSNID
-                     ('snana-2007nc', 'SN Ib'),   # sdss019323
-                     ('snana-2004hx', 'SN IIP'),  # sdss000018 PSNID
-                     ('snana-2005gi', 'SN IIP'),  # sdss003818 PSNID
-                     ('snana-2006gq', 'SN IIP'),  # sdss013376
-                     ('snana-2006kn', 'SN IIP'),  # sdss014450
-                     ('snana-2006jl', 'SN IIP'),  # sdss014599 PSNID
-                     ('snana-2006iw', 'SN IIP'),  # sdss015031
-                     ('snana-2006kv', 'SN IIP'),  # sdss015320
-                     ('snana-2006ns', 'SN IIP'),  # sdss015339
-                     ('snana-2007iz', 'SN IIP'),  # sdss017564
-                     ('snana-2007nr', 'SN IIP'),  # sdss017862
-                     ('snana-2007kw', 'SN IIP'),  # sdss018109
-                     ('snana-2007ky', 'SN IIP'),  # sdss018297
-                     ('snana-2007lj', 'SN IIP'),  # sdss018408
-                     ('snana-2007lb', 'SN IIP'),  # sdss018441
-                     ('snana-2007ll', 'SN IIP'),  # sdss018457
-                     ('snana-2007nw', 'SN IIP'),  # sdss018590
-                     ('snana-2007ld', 'SN IIP'),  # sdss018596
-                     ('snana-2007md', 'SN IIP'),  # sdss018700
-                     ('snana-2007lz', 'SN IIP'),  # sdss018713
-                     ('snana-2007lx', 'SN IIP'),  # sdss018734
-                     ('snana-2007og', 'SN IIP'),  # sdss018793
-                     ('snana-2007ny', 'SN IIP'),  # sdss018834
-                     ('snana-2007nv', 'SN IIP'),  # sdss018892
-                     ('snana-2007pg', 'SN IIP'),  # sdss020038
-                     ('snana-2006ez', 'SN IIn'),  # sdss012842
-                     ('snana-2006ix', 'SN IIn')]:  # sdss013449
+models = [('snana-2004fe', 'SN Ic', 'CSP-2004fe.SED'),
+          ('snana-2004gq', 'SN Ic', 'CSP-2004gq.SED'),
+          ('snana-sdss004012', 'SN Ic', 'SDSS-004012.SED'),  # no IAU name
+          ('snana-2006fo', 'SN Ic', 'SDSS-013195.SED'),  # PSNID
+          ('snana-sdss014475', 'SN Ic', 'SDSS-014475.SED'),  # no IAU name
+          ('snana-2006lc', 'SN Ic', 'SDSS-015475.SED'),
+          ('snana-2007ms', 'SN II-pec', 'SDSS-017548.SED'),  # type Ic in SNANA
+          ('snana-04D1la', 'SN Ic', 'SNLS-04D1la.SED'),
+          ('snana-04D4jv', 'SN Ic', 'SNLS-04D4jv.SED'),
+          ('snana-2004gv', 'SN Ib', 'CSP-2004gv.SED'),
+          ('snana-2006ep', 'SN Ib', 'CSP-2006ep.SED'),
+          ('snana-2007Y', 'SN Ib', 'CSP-2007Y.SED'),
+          ('snana-2004ib', 'SN Ib', 'SDSS-000020.SED'),
+          ('snana-2005hm', 'SN Ib', 'SDSS-002744.SED'),  # PSNID
+          ('snana-2006jo', 'SN Ib', 'SDSS-014492.SED'),  # PSNID
+          ('snana-2007nc', 'SN Ib', 'SDSS-019323.SED'),
+          ('snana-2004hx', 'SN IIP', 'SDSS-000018.SED'),  # PSNID
+          ('snana-2005gi', 'SN IIP', 'SDSS-003818.SED'),  # PSNID
+          ('snana-2006gq', 'SN IIP', 'SDSS-013376.SED'),
+          ('snana-2006kn', 'SN IIP', 'SDSS-014450.SED'),
+          ('snana-2006jl', 'SN IIP', 'SDSS-014599.SED'),  # PSNID
+          ('snana-2006iw', 'SN IIP', 'SDSS-015031.SED'),
+          ('snana-2006kv', 'SN IIP', 'SDSS-015320.SED'),
+          ('snana-2006ns', 'SN IIP', 'SDSS-015339.SED'),
+          ('snana-2007iz', 'SN IIP', 'SDSS-017564.SED'),
+          ('snana-2007nr', 'SN IIP', 'SDSS-017862.SED'),
+          ('snana-2007kw', 'SN IIP', 'SDSS-018109.SED'),
+          ('snana-2007ky', 'SN IIP', 'SDSS-018297.SED'),
+          ('snana-2007lj', 'SN IIP', 'SDSS-018408.SED'),
+          ('snana-2007lb', 'SN IIP', 'SDSS-018441.SED'),
+          ('snana-2007ll', 'SN IIP', 'SDSS-018457.SED'),
+          ('snana-2007nw', 'SN IIP', 'SDSS-018590.SED'),
+          ('snana-2007ld', 'SN IIP', 'SDSS-018596.SED'),
+          ('snana-2007md', 'SN IIP', 'SDSS-018700.SED'),
+          ('snana-2007lz', 'SN IIP', 'SDSS-018713.SED'),
+          ('snana-2007lx', 'SN IIP', 'SDSS-018734.SED'),
+          ('snana-2007og', 'SN IIP', 'SDSS-018793.SED'),
+          ('snana-2007ny', 'SN IIP', 'SDSS-018834.SED'),
+          ('snana-2007nv', 'SN IIP', 'SDSS-018892.SED'),
+          ('snana-2007pg', 'SN IIP', 'SDSS-020038.SED'),
+          ('snana-2006ez', 'SN IIn', 'SDSS-012842.SED'),
+          ('snana-2006ix', 'SN IIn', 'SDSS-013449.SED')]
+for name, sntype, fn in models:
+    relpath = 'models/snana/' + fn
     meta = {'url': url, 'subclass': subclass, 'type': sntype, 'ref': ref,
             'note': note}
     registry.register_loader(Source, name, load_timeseries_ascii,
-                             version='1.0', meta=meta)
+                             args=[relpath], version='1.0', meta=meta)
 
 
 # Pop III CC SN models from D.Whalen et al. 2013.
@@ -567,10 +567,17 @@ meta = {'type': 'PopIII',
                       'Whalen et al. 2013 '
                       '<http://adsabs.harvard.edu/abs/2013ApJ...768...95W>'),
         'note': "private communication (D.Whalen, May 2014)."}
-for name in ['whalen-z15b', 'whalen-z15d', 'whalen-z15g', 'whalen-z25b',
-             'whalen-z25d', 'whalen-z25g', 'whalen-z40b', 'whalen-z40g']:
+for name, fn in [('whalen-z15b', 'popIII-z15B.sed.restframe10pc.dat'),
+                 ('whalen-z15d', 'popIII-z15D.sed.restframe10pc.dat'),
+                 ('whalen-z15g', 'popIII-z15G.sed.restframe10pc.dat'),
+                 ('whalen-z25b', 'popIII-z25B.sed.restframe10pc.dat'),
+                 ('whalen-z25d', 'popIII-z25D.sed.restframe10pc.dat'),
+                 ('whalen-z25g', 'popIII-z25G.sed.restframe10pc.dat'),
+                 ('whalen-z40b', 'popIII-z40B.sed.restframe10pc.dat'),
+                 ('whalen-z40g', 'popIII-z40G.sed.restframe10pc.dat')]:
+    relpath = 'models/whalen/' + fn
     registry.register_loader(Source, name, load_timeseries_ascii,
-                             version='1.0', meta=meta)
+                             args=[relpath], version='1.0', meta=meta)
 
 
 # =============================================================================
@@ -587,7 +594,9 @@ website = 'ftp://ftp.stsci.edu/cdbs/calspec/'
 subclass = '`~sncosmo.SpectralMagSystem`'
 vega_desc = 'Vega (alpha lyrae) has magnitude 0 in all bands.'
 bd17_desc = 'BD+17d4708 has magnitude 0 in all bands.'
-for name, desc in [('vega', vega_desc), ('bd17', bd17_desc)]:
+for name, fn, desc in [('vega', 'alpha_lyr_stis_007.fits', vega_desc),
+                       ('bd17', 'bd_17d4708_stisnic_005.fits', bd17_desc)]:
     registry.register_loader(MagSystem, name, load_spectral_magsys_fits,
+                             args=['spectra/' + fn],
                              meta={'subclass': subclass, 'url': website,
                                    'description': desc})

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -516,8 +516,8 @@ models = [('snana-2004fe', 'SN Ic', 'CSP-2004fe.SED'),
           ('snana-sdss014475', 'SN Ic', 'SDSS-014475.SED'),  # no IAU name
           ('snana-2006lc', 'SN Ic', 'SDSS-015475.SED'),
           ('snana-2007ms', 'SN II-pec', 'SDSS-017548.SED'),  # type Ic in SNANA
-          ('snana-04D1la', 'SN Ic', 'SNLS-04D1la.SED'),
-          ('snana-04D4jv', 'SN Ic', 'SNLS-04D4jv.SED'),
+          ('snana-04d1la', 'SN Ic', 'SNLS-04D1la.SED'),
+          ('snana-04d4jv', 'SN Ic', 'SNLS-04D4jv.SED'),
           ('snana-2004gv', 'SN Ib', 'CSP-2004gv.SED'),
           ('snana-2006ep', 'SN Ib', 'CSP-2006ep.SED'),
           ('snana-2007Y', 'SN Ib', 'CSP-2007Y.SED'),

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -14,7 +14,7 @@ from os.path import join
 import numpy as np
 from astropy import wcs, units as u
 from astropy.io import ascii, fits
-from astropy.config import ConfigurationItem
+from astropy.config import ConfigurationItem, get_cache_dir
 from astropy.extern import six
 from astropy.utils import OrderedDict
 from astropy.utils.data import (download_file, get_pkg_data_filename,
@@ -25,6 +25,7 @@ from . import io
 from .models import Source, TimeSeriesSource, SALT2Source
 from .spectral import (Bandpass, read_bandpass, Spectrum, MagSystem,
                        SpectralMagSystem, ABMagSystem)
+from . import conf
 
 # Dictionary of urls
 urls = None
@@ -43,7 +44,17 @@ def get_url(name, version=None):
         f.close()
 
     key = name if (version is None) else "{0}_v{1}".format(name, version)
+
     return urls[key]
+
+
+def full_data_name(name):
+    """Return the full path to a local resource, by prepending conf.data_dir
+    if set or (astropy cache dir)/sncosmo."""
+    if conf.data_dir is not None:
+        return join(conf.data_dir, name)
+    else:
+        return join(get_cache_dir(), "sncosmo", name)
 
 
 def load_bandpass_angstroms(pkg_data_name, name=None):

--- a/sncosmo/sncosmo.cfg
+++ b/sncosmo/sncosmo.cfg
@@ -1,0 +1,10 @@
+
+## Directory containing SFD (1998) dust maps, with names:
+## 'SFD_dust_4096_ngp.fits' and 'SFD_dust_4096_sgp.fits'
+## Example: sfd98_dir = /home/user/data/sfd98
+# sfd98_dir = None
+
+## Directory where sncosmo will store and read downloaded data resources.
+## If None, ASTROPY_CACHE_DIR/sncosmo will be used.
+## Example: data_dir = /home/user/data/sncosmo
+# data_dir = None

--- a/sncosmo/utils.py
+++ b/sncosmo/utils.py
@@ -203,7 +203,7 @@ def _download_file(remote_url, target):
     """
 
     from contextlib import closing
-    from six.moves.urllib.request import urlopen
+    from six.moves.urllib.request import urlopen, Request
     from six.moves.urllib.error import URLError
     from astropy.utils.console import ProgressBarOrSpinner
     from astropy.utils.data import conf
@@ -211,7 +211,13 @@ def _download_file(remote_url, target):
     timeout = conf.remote_timeout
 
     try:
-        with closing(urlopen(remote_url, timeout=timeout)) as remote:
+        # Pretend to be a web browser (IE 6.0). Some servers that we download
+        # from forbid access from programs.
+        headers = {'User-Agent': 'Mozilla/5.0',
+                   'Accept': ('text/html,application/xhtml+xml,'
+                              'application/xml;q=0.9,*/*;q=0.8')}
+        req = Request(remote_url, headers=headers)
+        with closing(urlopen(req, timeout=timeout)) as remote:
 
             # get size of remote if available (for use in progress bar)
             info = remote.info()

--- a/sncosmo/utils.py
+++ b/sncosmo/utils.py
@@ -1,3 +1,5 @@
+import sys
+import io
 import math
 
 import numpy as np
@@ -188,3 +190,140 @@ def weightedcov(x, w):
     cov = wsum / (wsum**2 - w2sum) * np.einsum('i,ij,ik', w, xd, xd)
 
     return xmean, cov
+
+
+def _download_file(remote_url, target):
+    """
+    Accepts a URL, downloads the file to a given open file object.
+
+    This is a modified version of astropy.utils.data.download_file that
+    downloads to an open file object instead of a cache directory.
+    """
+
+    from contextlib import closing
+    from six.moves.urllib.request import urlopen
+    from six.moves.urllib.error import URLError
+    from astropy.utils.console import ProgressBarOrSpinner
+    from astropy.utils.data import conf
+
+    timeout = conf.remote_timeout
+
+    try:
+        with closing(urlopen(remote_url, timeout=timeout)) as remote:
+
+            # get size of remote if available (for use in progress bar)
+            info = remote.info()
+            size = None
+            if 'Content-Length' in info:
+                try:
+                    size = int(info['Content-Length'])
+                except ValueError:
+                    pass
+
+            dlmsg = "Downloading {0}".format(remote_url)
+            with ProgressBarOrSpinner(size, dlmsg) as p:
+                bytes_read = 0
+                block = remote.read(conf.download_block_size)
+                while block:
+                    target.write(block)
+                    bytes_read += len(block)
+                    p.update(bytes_read)
+                    block = remote.read(conf.download_block_size)
+
+    # Append a more informative error message to URLErrors.
+    except URLError as e:
+        append_msg = (hasattr(e, 'reason') and hasattr(e.reason, 'errno') and
+                      e.reason.errno == 8)
+        if append_msg:
+            msg = "{0}. requested URL: {1}".format(e.reason.strerror,
+                                                   remote_url)
+            e.reason.strerror = msg
+            e.reason.args = (e.reason.errno, msg)
+        raise e
+
+    # This isn't supposed to happen, but occasionally a socket.timeout gets
+    # through.  It's supposed to be caught in `urrlib2` and raised in this
+    # way, but for some reason in mysterious circumstances it doesn't. So
+    # we'll just re-raise it here instead.
+    except socket.timeout as e:
+        raise URLError(e)
+
+
+def download_file(remote_url, local_name)
+    """
+    Download a remote file to local path, unzipping if the URL ends in '.gz'.
+
+    Parameters
+    ----------
+    remote_url : str
+        The URL of the file to download
+
+    local_name : str
+        Absolute path filename of target file.
+
+    Raises
+    ------
+    URLError (from urllib2 on PY2, urllib.request on PY3)
+        Whenever there's a problem getting the remote file.
+    """
+
+    # ensure target directory exists
+    dn = os.path.dirname(local_name)
+    if not os.path.exists(dn):
+        os.makedirs(dn)
+
+    if remote_url.endswith(".gz"):
+        import io
+        from astropy.compat import gzip
+
+        buf = io.BytesIO()
+        _download_file(remote_url, buf)
+        buf.seek(0)
+        f = gzip.GzipFile(fileobj=buf, mode='rb')
+
+        with open(local_name, 'wb') as target:
+            target.write(f.read())
+        f.close()
+
+    else:
+        with open(local_name, 'wb') as target:
+            _download_file(remote_url, target)
+
+
+def download_dir(remote_url, dirname)
+    """
+    Download a remote tar file to a local directory.
+
+    Parameters
+    ----------
+    remote_url : str
+        The URL of the file to download
+
+    dirname : str
+        Directory in which to place contents of tarfile. Created if it
+        doesn't exist.
+
+    Raises
+    ------
+    URLError (from urllib2 on PY2, urllib.request on PY3)
+        Whenever there's a problem getting the remote file.
+    """
+
+    import io
+    import tarfile
+
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
+
+    mode = 'r:gz' if remote_url.endswith(".gz") else None
+
+    # download file to buffer
+    buf = io.BytesIO()
+    _download_file(remote_url, buf)
+    buf.seek(0)
+    
+    # create a tarfile with the buffer and extract
+    tf = tarfile.open(fileobj=buf, mode=mode)
+    tf.extractall(path=dirname)
+    tf.close()
+    f.close()  # f not closed when tf is closed.

--- a/sncosmo/utils.py
+++ b/sncosmo/utils.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
+
+import os
 import sys
-import io
 import math
 
 import numpy as np
@@ -249,7 +251,7 @@ def _download_file(remote_url, target):
         raise URLError(e)
 
 
-def download_file(remote_url, local_name)
+def download_file(remote_url, local_name):
     """
     Download a remote file to local path, unzipping if the URL ends in '.gz'.
 
@@ -274,7 +276,7 @@ def download_file(remote_url, local_name)
 
     if remote_url.endswith(".gz"):
         import io
-        from astropy.compat import gzip
+        from astropy.utils.compat import gzip
 
         buf = io.BytesIO()
         _download_file(remote_url, buf)
@@ -290,7 +292,7 @@ def download_file(remote_url, local_name)
             _download_file(remote_url, target)
 
 
-def download_dir(remote_url, dirname)
+def download_dir(remote_url, dirname):
     """
     Download a remote tar file to a local directory.
 
@@ -321,9 +323,9 @@ def download_dir(remote_url, dirname)
     buf = io.BytesIO()
     _download_file(remote_url, buf)
     buf.seek(0)
-    
+
     # create a tarfile with the buffer and extract
     tf = tarfile.open(fileobj=buf, mode=mode)
     tf.extractall(path=dirname)
     tf.close()
-    f.close()  # f not closed when tf is closed.
+    buf.close()  # buf not closed when tf is closed.


### PR DESCRIPTION
Addresses #5.

This is quite a big change, but one that should be transparent to most users. There could be some bugs lurking so I'd like people to be aware of the change and test out the code before the next version release.

Currently, data for models and spectra are automatically downloaded to the astropy cache directory (`~/.astropy/cache`) and stored according to their hash. So, you get a directory that looks like this:

```
$ ls ~/.astropy/cache/
download  download_urlmap
$ ls ~/.astropy/cache/download
1111745bc9bbf715ec14062ccf43d50e  96e33cf2cc22779e06ac6cf3594d77eb
121927c70484bf2f11298465210fc1a1  badbbb2dee07bf37b3dbe1af249f7573
4bdca598433a23d915fe87ed2182fec2  dc41b35e9a7fc049f3c129b496d40382
83051c9dca9d0139d95a246934fc7b71
```

Those are the data files, but it is nearly impossible to tell which is which! Furthermore, .tar.gz and .gz files are not uncompressed before storing, so they cannot be easily inspected by users who might want to know what the "raw" data for a model looks like on disk.

With this PR, the models are now stored in `~/.astropy/cache/sncosmo` in a transparent fashion. (This target directory can be changed by setting the `data_dir` configuration parameter in `~/.astropy/config/sncosmo.cfg`). For example, after downloading three models, this is what the directory looks like:

```
$ tree ~/.astropy/cache/sncosmo/
/home/kyle/.astropy/cache/sncosmo/
└── models
    ├── sako
    │   └── S11_SDSS-000018.SED
    ├── salt2
    │   └── salt2-4
    │       ├── salt2_color_correction.dat
    │       ├── salt2_color_dispersion.dat
    │       ├── salt2_lc_dispersion_scaling.dat
    │       ├── salt2_lc_relative_covariance_01.dat
    │       ├── salt2_lc_relative_variance_0.dat
    │       ├── salt2_lc_relative_variance_1.dat
    │       ├── salt2_spec_covariance_01.dat
    │       ├── salt2_spec_variance_0.dat
    │       ├── salt2_spec_variance_1.dat
    │       ├── salt2_template_0.dat
    │       └── salt2_template_1.dat
    └── snana
        └── salt2_extended
            ├── AAA_README
            ├── salt2_color_correction.dat
            ├── salt2_color_dispersion.dat
            ├── SALT2.INFO
            ├── salt2_lc_dispersion_scaling.dat
            ├── salt2_lc_relative_covariance_01.dat
            ├── salt2_lc_relative_variance_0.dat
            ├── salt2_lc_relative_variance_1.dat
            ├── salt2_spec_covariance_01.dat
            ├── salt2_spec_variance_0.dat
            ├── salt2_spec_variance_1.dat
            ├── salt2_template_0.dat
            └── salt2_template_1.dat
```

**Auxiliary benefits:**

- no longer uses BSDDB module (used in astropy remote cacheing code) which has caused problems for us in the past.
- multiple users can share a single data directory, by setting the `data_dir` config parameter.
- users can download data on one machine and copy the data directory to another machine (useful if the target machine doesn't have internet access)
- allows us to customize the URL request, fixing an apparent bug with downloading the SALT2 models currently.