### PR TITLE
add 'zero_before' keyword for Whalen models

### DIFF
--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -137,10 +137,11 @@ def tophat_bandpass(ctr, width, name=None):
     return Bandpass(wave, trans, wave_unit=u.micron, name=name)
 
 
-def load_timeseries_ascii(relpath, name=None, version=None):
+def load_timeseries_ascii(relpath, zero_before=False, name=None, version=None):
     abspath = get_abspath(relpath, name, version=version)
     phase, wave, flux = io.read_griddata_ascii(abspath)
-    return TimeSeriesSource(phase, wave, flux, name=name, version=version)
+    return TimeSeriesSource(phase, wave, flux, name=name, version=version,
+                            zero_before=zero_before)
 
 
 def load_timeseries_fits(relpath, name=None, version=None):
@@ -576,7 +577,7 @@ for name, fn in [('whalen-z15b', 'popIII-z15B.sed.restframe10pc.dat'),
                  ('whalen-z40g', 'popIII-z40G.sed.restframe10pc.dat')]:
     relpath = 'models/whalen/' + fn
     registry.register_loader(Source, name, load_timeseries_ascii,
-                             args=[relpath], version='1.0', meta=meta)
+                             args=[relpath, True], version='1.0', meta=meta)
 
 
 # =============================================================================


### PR DESCRIPTION
This is my solution to #69, an alternative solution to #72.

It has the benefit of being minimally intrusive to models that don't need the check. (In fact, you don't want the check for most models because it creates a discontinuity that will make fitting harder.) There's a lot of different ways you could accomplish the same thing. For example, one could implement a subclass of `RectBivariateSpline` or of `TimeSeriesSource` that does the check. This solution simply adds a keyword argument to the initializer in `TimeSeriesSource`. This seems like the simplest thing to do for now.

With this change:
```python
In [5]: model = sncosmo.Model(source='whalen-z15b')

In [6]: model.source.minphase()
Out[6]: 1.6599999999999999

In [8]: model.flux(1.6, [100., 200.])
Out[8]: array([ 0.,  0.])
```
Does this look good @srodney?