### PR TITLE
builtins: added bytes-to-string decoder since urllib.urlopen() returns bytes instead of a string in Python 3

### DIFF
--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -11,6 +11,7 @@ import tarfile
 import warnings
 import os
 from os.path import join
+import codecs
 
 import numpy as np
 from astropy import wcs, units as u
@@ -44,7 +45,8 @@ def get_url(name, version=None):
         from six.moves.urllib.request import urlopen
         import json
         f = urlopen("http://sncosmo.github.io/data/urls.json")
-        urls = json.load(f)
+        reader = codecs.getreader("utf-8")
+        urls = json.load(reader(f))
         f.close()
 
     key = name if (version is None) else "{0}_v{1}".format(name, version)


### PR DESCRIPTION
This fixes a bug when trying to import a supernova model for the first
time in Python 3. json.load() needs a string argument, but in Python 3,
urllib.urlopen() returns raw bytes. (In Python 2 it returns a string as
the code expects currently.) The fix yields identical behavior in both
Python 2 and 3.

Note that the bug does not trigger in either version of Python if the
requested model has already been downloaded and cached.

This fixes #83.

Signed-off-by: Brian Friesen <friesen@ou.edu>