### PR TITLE
io: force bytes-to-string decoding of "line" argument to _stripcomment()

### DIFF
--- a/sncosmo/io.py
+++ b/sncosmo/io.py
@@ -74,7 +74,7 @@ def read_griddata_ascii(name_or_obj):
     x1_current = []
     y1_current = []
     for line in f:
-        stripped_line = _stripcomment(line)
+        stripped_line = _stripcomment(line.decode("utf-8"))
         if len(stripped_line) == 0:
             continue
         x0_tmp, x1_tmp, y_tmp = map(float, stripped_line.split())


### PR DESCRIPTION
When importing some of the built-in supernova models for the first time
(e.g., `s11-2006jl`), the model data is downloaded and parsed with
`read_griddata_ascii()`. In `read_griddata_ascii()` each line from the file
object is passed to `_stripcomment()` to remove comment text. However in
Python 3 the `line` argument to `_stripcomment()` is raw bytes, which
leads to the TypeError `Type str doesn't support the buffer API`. In
Python 2 the error does not trigger because the `line` argument is
interpreted as a string.

This fixes #85 by explicitly decoding the `line` argument as a string.

Signed-off-by: Brian Friesen <friesen@ou.edu>