### PR TITLE
io: change read mode of file in read_griddata_ascii() to raw text

### DIFF
--- a/sncosmo/io.py
+++ b/sncosmo/io.py
@@ -62,7 +62,7 @@ def read_griddata_ascii(name_or_obj):
     """
 
     if isinstance(name_or_obj, six.string_types):
-        f = open(name_or_obj, 'rb')
+        f = open(name_or_obj, 'r')
     else:
         f = name_or_obj
 


### PR DESCRIPTION
When the read mode is set to `rb`, Python 3 throws the TypeError `Type
str doesn't support the buffer API`, although Python 2 doesn't mind.
Changing `rb` to `r` makes both Python 2 and 3 happy.

This error is only triggered when importing a new supernova model. And
even then only some models invoke `read_griddata_ascii()`, e.g.,
`'nugent-sn1a'`, but not `'hsiao'`.

This fixes #85.

Signed-off-by: Brian Friesen <friesen@ou.edu>