### PR TITLE
Use astropy.extern.six for import in plotting.py

### DIFF
--- a/sncosmo/plotting.py
+++ b/sncosmo/plotting.py
@@ -7,7 +7,7 @@ import math
 import numpy as np
 from astropy.utils.misc import isiterable
 from astropy.extern import six
-from six.moves import range
+from astropy.extern.six.moves import range
 
 from .models import Source, Model, get_source
 from .spectral import get_bandpass, get_magsystem


### PR DESCRIPTION
I'm guessing that the import of range is intended to be from astropy's copy of six since six isn't listed as a dependency in setup. This PR corrects the import (and is motivated by work on auto-building conda packages for astropy-affiliated packages).