### PR TITLE
Fix Semantic Versioning URL

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -76,7 +76,7 @@ Version History
 
 This package uses `Semantic Versioning`_.
 
-.. _`Semantic Versioning`: http:\\semver.org
+.. _`Semantic Versioning`: http://semver.org
 
 Contributors
 ============


### PR DESCRIPTION
Fixes two backslashes that should have been forward slashes to fix semver.org reference.