### PR TITLE
Doc typos

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -88,5 +88,4 @@ Contributors
 * Tom Barclay
 * Rollin C. Thomas
 * Danny Goldstein
-
- LocalWords:  sncosmo
+* Michael Wood-Vasey

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -88,3 +88,5 @@ Contributors
 * Tom Barclay
 * Rollin C. Thomas
 * Danny Goldstein
+
+ LocalWords:  sncosmo

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -49,7 +49,7 @@ supernova cosmology. These include (but are not limited to) `snfit`_
   with a (mostly) different feature set. The current maintenance and
   development status of the package is unclear.
 
-.. _`snfit`: http://supernovae.in2p3.fr/~guy/salt/index.html
+.. _`snfit`: http://supernovae.in2p3.fr/salt
 .. _`SNANA`: http://sdssdp62.fnal.gov/sdsssn/SNANA-PUBLIC/
 .. _`SNooPy`: http://csp.obs.carnegiescience.edu/data/snpy
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -43,7 +43,7 @@ A Model in sncosmo consists of
 
 * **One "source"** A model of the spectral evolution of the source
   (e.g., a supernova).
-* **Zero or more "propagation effects"** Models of how interveneing structures
+* **Zero or more "propagation effects"** Models of how intervening structures
   (e.g., host galaxy dust, milky way dust) affect the spectrum.
 
 In the above example, we created a model with no propagation effects,

--- a/docs/registry.rst
+++ b/docs/registry.rst
@@ -79,7 +79,7 @@ might only want to load them as they are needed, rather than having to
 load everything into memory when you do ``import mydefs``. You can use
 the `sncosmo.registry.register_loader` function. Suppose we have a
 bandpass that requires a huge data file (In reality it is unlikely
-that loading bandpasses would take a noticable amount of time, but it
+that loading bandpasses would take a noticeable amount of time, but it
 might for models or spectra.)::
 
     # contents of mydefs.py

--- a/docs/simulation.rst
+++ b/docs/simulation.rst
@@ -3,7 +3,7 @@ Simulation
 ==========
 
 First, define a set of "observations". These are the properties of our
-obsevations: the time, bandpass and depth.
+observations: the time, bandpass and depth.
 
 .. code:: python
 
@@ -59,7 +59,7 @@ Generating SN parameters
 
 We see above that it is straightforward to simulate SNe once we already
 know the parameters of each one. But what if we want to pick SN
-parmeters from some defined distribution?
+parameters from some defined distribution?
 
 Suppose we want to generate SN parameters for all the SNe we would find
 in a given search area over a defined period of time. We start by
@@ -114,7 +114,7 @@ and ``c`` from normal distributions:
 
 
 So far so good. The only problem is that ``x0`` doesn't vary. We'd like
-it to be randomly distributed with some scatter around the hubble line,
+it to be randomly distributed with some scatter around the Hubble line,
 so it should depend on the redshift. Here's an alternative:
 
 .. code:: python


### PR DESCRIPTION
Fixes URL for snfit/SALT (which has been moved from Julien Guy's personal page to a more general URL).

Fixes some typos/misspellings in some of the docs.