### PR TITLE
bumped astropy to 0.4.0

### DIFF
--- a/pip-requirements
+++ b/pip-requirements
@@ -1,3 +1,3 @@
 numpy>=1.5.0
 scipy>=0.9.0
-astropy>=0.3.0
+astropy>=0.4.0


### PR DESCRIPTION
 I tried installing on a machine with astropy 0.3.0 (the current version in the Ubuntu 14.04 repositories).

When I try importing I get the following error:
```
>>> import sncosmo
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ufein/.virtualenvs/sncosmo-test/local/lib/python2.7/site-packages/sncosmo/__init__.py", line 124, in <module>
    from astropy.config import ConfigItem, ConfigNamespace
ImportError: cannot import name ConfigItem
```

`ConfigItem` does not exist before astropy 0.4.0, so I the requirement should be bumped to the version. I quickly verified that it work with that version in separate virtualenvs.

Unless I'm mistaken `pip-requirements` is all that needs to be changed.