### PR TITLE
flatten registry namespace; reorder API doc page

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -15,23 +15,25 @@ Built-ins
 
 .. currentmodule:: sncosmo
 
-Model & Sources
-===============
+Model & Components
+==================
 
 .. autosummary::
    :toctree: api
 
-   get_source
+   Model
+
+*Source component of Model*
+
+.. autosummary::
+   :toctree: api
+
    Source
    TimeSeriesSource
    StretchSource
    SALT2Source
-   Model
 
-PropagationEffects
-==================
-
-*Adding interstellar dust extinction to models*
+*Effect components of Model: interstellar dust extinction*
 
 .. autosummary::
    :toctree: api
@@ -41,22 +43,13 @@ PropagationEffects
    OD94Dust
    F99Dust
 
-Bandpasses
-==========
+Bandpass & Magnitude Systems
+============================
 
 .. autosummary::
    :toctree: api
 
-   get_bandpass
    Bandpass
-
-Magnitude Systems
-=================
-
-.. autosummary::
-   :toctree: api
-
-   get_magsystem
    MagSystem
    ABMagSystem
    SpectralMagSystem
@@ -89,7 +82,7 @@ maps, and more.*
 Fitting Photometric Data
 ========================
 
-*Fit model parameters to photometric data*
+*Estimate model parameters from photometric data*
 
 .. autosummary::
    :toctree: api
@@ -97,8 +90,15 @@ Fitting Photometric Data
    fit_lc
    mcmc_lc
    nest_lc
+
+*Convenience functions*
+
+.. autosummary::
+   :toctree: api
+
    chisq
    flatten_result
+
 
 Plotting
 ========
@@ -123,14 +123,17 @@ Simulation
 Registry
 ========
 
-*Connecting strings to models, bandpasses, and magnitude systems*
+*Register and retrieve custom built-in sources, bandpasses, and
+magnitude systems*
 
 .. autosummary::
    :toctree: api
 
-   registry.register_loader
-   registry.register
-   registry.retrieve
+   register
+   register_loader
+   get_source
+   get_bandpass
+   get_magsystem
 
 Class Inheritance Diagrams
 ==========================
@@ -143,4 +146,3 @@ Class Inheritance Diagrams
 
 .. inheritance-diagram:: MagSystem ABMagSystem SpectralMagSystem
    :parts: 1
-

--- a/sncosmo/__init__.py
+++ b/sncosmo/__init__.py
@@ -152,8 +152,7 @@ if not _ASTROPY_SETUP_:
     # clean up namespace
     del os, ConfigItem, ConfigNamespace, update_default_config
 
-    # Do all the necessary imports: everything except registry goes in the
-    # top-level namespace.
+    # Do all the necessary imports.
     from .dustmap import *
     from .spectral import *
     from .models import *
@@ -162,6 +161,9 @@ if not _ASTROPY_SETUP_:
     from .fitting import *
     from .simulation import *
     from .plotting import *
-    from . import registry
+    from .registry import *
 
+    from . import registry  # deprecated in v1.2; use previous import.
+
+    # Register all the built-ins.
     from .builtins import *

--- a/sncosmo/registry.py
+++ b/sncosmo/registry.py
@@ -5,7 +5,7 @@ based on string identifiers."""
 from astropy.utils import OrderedDict
 from astropy.extern import six
 
-__all__ = ['register_loader', 'register', 'retrieve', 'get_loaders_metadata']
+__all__ = ['register_loader', 'register']
 
 _loaders = OrderedDict()
 _instances = OrderedDict()
@@ -14,6 +14,9 @@ _instances = OrderedDict()
 def register_loader(data_class, name, func, args=None,
                     version=None, meta=None, force=False):
     """Register a data reading function.
+
+    .. note:: Formerly accessed as ``sncosmo.registry.register_loader`` prior
+              to v1.2.
 
     Parameters
     ----------
@@ -64,6 +67,9 @@ def register_loader(data_class, name, func, args=None,
 
 def register(instance, name=None, data_class=None, force=False):
     """Register a class instance.
+
+    .. note:: Formerly accessed as ``sncosmo.registry.register`` prior
+              to v1.2.
 
     Parameters
     ----------

--- a/sncosmo/tests/test_registry.py
+++ b/sncosmo/tests/test_registry.py
@@ -8,13 +8,16 @@ import sncosmo
 def test_register():
     disp = np.array([4000., 4200., 4400., 4600., 4800., 5000.])
     trans = np.array([0., 1., 1., 1., 1., 0.])
+
+    # create a band, register it, make sure we can get it back.
     band = sncosmo.Bandpass(disp, trans, name='tophatg')
+    sncosmo.register(band)
+    assert sncosmo.get_bandpass('tophatg') is band
+
+    # test deprecated path to registry
+    band = sncosmo.Bandpass(disp, trans, name='tophatg2')
     sncosmo.registry.register(band)
-
-    band2 = sncosmo.get_bandpass('tophatg')
-
-    # make sure we can get back the band we put it.
-    assert band2 is band
+    assert sncosmo.get_bandpass('tophatg2') is band
 
 
 def test_retrieve_cases():


### PR DESCRIPTION
This addresses #90 by undocumenting the `sncosmo.registry.retrieve` function. One should instead use `sncosmo.get_source`, `sncosmo.get_bandpass`, `sncosmo.get_magsystem`.

It also moves the registry functions into the top level namespace: 
- `sncosmo.registry.register` -> `sncosmo.register`
- `sncosmo.registry.register_loader` -> `sncosmo.register_loader`

The old import paths will still work, so this is backwards compatible.

Finally, it tweaks the organization of the Reference/API doc page.