### PR TITLE
travis: use release iminuit on py3

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -46,14 +46,7 @@ fi
 if $OPTIONAL_DEPS
 then
   $CONDA_INSTALL matplotlib
-  $PIP_INSTALL emcee nestle
-  if [[ $PYTHON_VERSION < 3 ]]
-  then
-      $PIP_INSTALL iminuit
-  else
-      # need dev version of iminuit on Python 3
-      $PIP_INSTALL git+http://github.com/iminuit/iminuit.git#egg=iminuit
-  fi
+  $PIP_INSTALL emcee nestle iminuit
 fi
 
 # DOCUMENTATION DEPENDENCIES


### PR DESCRIPTION
The new iminuit 1.2 release supports Python 3, so we no longer need to use the dev version on Python 3.