### PR TITLE
add LocalMagSystem & 'csp' magsystem built-in

### DIFF
--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -26,7 +26,7 @@ from . import io
 from .utils import download_file, download_dir
 from .models import Source, TimeSeriesSource, SALT2Source, MLCS2k2Source
 from .spectral import (Bandpass, read_bandpass, Spectrum, MagSystem,
-                       SpectralMagSystem, ABMagSystem, LocalMagSystem)
+                       SpectralMagSystem, ABMagSystem, CompositeMagSystem)
 from . import conf
 
 # This module is only imported for its side effects.
@@ -262,7 +262,7 @@ def load_csp(**kwargs):
         bands = np.char.decode(bands)
         refsystems = np.char.decode(refsystems)
 
-    return LocalMagSystem(bands, refsystems, offsets, name='csp')
+    return CompositeMagSystem(bands, refsystems, offsets, name='csp')
 
 
 # =============================================================================
@@ -684,6 +684,6 @@ for name, fn, desc in [('vega', 'alpha_lyr_stis_007.fits', vega_desc),
 # CSP
 registry.register_loader(
     MagSystem, 'csp', load_csp,
-    meta={'subclass': '`~sncosmo.LocalMagSystem`',
+    meta={'subclass': '`~sncosmo.CompositeMagSystem`',
           'url': 'http://csp.obs.carnegiescience.edu/data/filters',
           'description': 'Carnegie Supernova Project magnitude system.'})

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -26,7 +26,7 @@ from . import io
 from .utils import download_file, download_dir
 from .models import Source, TimeSeriesSource, SALT2Source, MLCS2k2Source
 from .spectral import (Bandpass, read_bandpass, Spectrum, MagSystem,
-                       SpectralMagSystem, ABMagSystem)
+                       SpectralMagSystem, ABMagSystem, LocalMagSystem)
 from . import conf
 
 # This module is only imported for its side effects.
@@ -244,7 +244,26 @@ def load_spectral_magsys_fits(relpath, name=None):
     hdulist.close()
     refspectrum = Spectrum(dispersion, flux_density,
                            unit=(u.erg / u.s / u.cm**2 / u.AA), wave_unit=u.AA)
+
     return SpectralMagSystem(refspectrum, name=name)
+
+
+def load_csp(**kwargs):
+
+    # this file contains the csp zeropoints and standards
+    fname = get_pkg_data_filename('data/bandpasses/csp/csp_filter_info.dat')
+    data = np.genfromtxt(fname, names=True, dtype=None, skip_header=3)
+    bands = data['name']
+    refsystems = data['reference_sed']
+    offsets = data['natural_mag']
+
+    # In Python 3, convert to native strings (Unicode)
+    if six.PY3:
+        bands = np.char.decode(bands)
+        refsystems = np.char.decode(refsystems)
+
+    return LocalMagSystem(bands, refsystems, offsets, name='csp')
+
 
 # =============================================================================
 # Bandpasses
@@ -661,3 +680,10 @@ for name, fn, desc in [('vega', 'alpha_lyr_stis_007.fits', vega_desc),
                              args=['spectra/' + fn],
                              meta={'subclass': subclass, 'url': website,
                                    'description': desc})
+
+# CSP
+registry.register_loader(
+    MagSystem, 'csp', load_csp,
+    meta={'subclass': '`~sncosmo.LocalMagSystem`',
+          'url': 'http://csp.obs.carnegiescience.edu/data/filters',
+          'description': 'Carnegie Supernova Project magnitude system.'})

--- a/sncosmo/spectral.py
+++ b/sncosmo/spectral.py
@@ -17,7 +17,7 @@ from . import registry
 
 __all__ = ['get_bandpass', 'get_magsystem', 'read_bandpass', 'Bandpass',
            'Spectrum', 'MagSystem', 'SpectralMagSystem', 'ABMagSystem',
-           'LocalMagSystem']
+           'CompositeMagSystem']
 
 HC_ERG_AA = const.h.cgs.value * const.c.to(u.AA / u.s).value
 
@@ -479,7 +479,7 @@ class MagSystem(object):
         return self.zpbandflux(band) * 10.**(-0.4 * mag)
 
 
-class LocalMagSystem(MagSystem):
+class CompositeMagSystem(MagSystem):
     """A magnitude system defined in a specific set of bands.
 
     In each band, there is a fundamental standard with a known
@@ -497,7 +497,7 @@ class LocalMagSystem(MagSystem):
     """
 
     def __init__(self, bands, standards, offsets, name=None):
-        super(LocalMagSystem, self).__init__(name=name)
+        super(CompositeMagSystem, self).__init__(name=name)
 
         if not len(bands) == len(offsets) == len(standards):
             raise ValueError('Lengths of bands, standards, and offsets '
@@ -529,7 +529,7 @@ class LocalMagSystem(MagSystem):
         return 10.**(0.4 * offset) * standard.zpbandflux(band)
 
     def __str__(self):
-        s = "LocalMagSystem {!r}:\n".format(self.name)
+        s = "CompositeMagSystem {!r}:\n".format(self.name)
 
         for i in range(len(self._bands)):
             s += "  {!r}: system={!r}  offset={}\n".format(

--- a/sncosmo/spectral.py
+++ b/sncosmo/spectral.py
@@ -16,7 +16,8 @@ from astropy import cosmology
 from . import registry
 
 __all__ = ['get_bandpass', 'get_magsystem', 'read_bandpass', 'Bandpass',
-           'Spectrum', 'MagSystem', 'SpectralMagSystem', 'ABMagSystem']
+           'Spectrum', 'MagSystem', 'SpectralMagSystem', 'ABMagSystem',
+           'LocalMagSystem']
 
 HC_ERG_AA = const.h.cgs.value * const.c.to(u.AA / u.s).value
 
@@ -476,6 +477,66 @@ class MagSystem(object):
     def band_mag_to_flux(self, mag, band):
         """Convert magnitude to flux in photons / s / cm^2"""
         return self.zpbandflux(band) * 10.**(-0.4 * mag)
+
+
+class LocalMagSystem(MagSystem):
+    """A magnitude system defined in a specific set of bands.
+
+    In each band, there is a fundamental standard with a known
+    (generally non-zero) magnitude.
+
+    Parameters
+    ----------
+    bands: iterable of `~sncosmo.Bandpass` or str
+        The filters in the magnitude system.
+    standards: iterable of `~sncosmo.MagSystem` or str,
+        The spectrophotmetric flux standards for each band, in the
+        same order as `bands`.
+    offsets: list_like
+        The magnitude of standard in the given band.
+    """
+
+    def __init__(self, bands, standards, offsets, name=None):
+        super(LocalMagSystem, self).__init__(name=name)
+
+        if not len(bands) == len(offsets) == len(standards):
+            raise ValueError('Lengths of bands, standards, and offsets '
+                             'must match.')
+
+        self._bands = [get_bandpass(band) for band in bands]
+        self._standards = [get_magsystem(s) for s in standards]
+        self._offsets = offsets
+
+    @property
+    def bands(self):
+        return self._bands
+
+    @property
+    def standards(self):
+        return self._standards
+
+    @property
+    def offsets(self):
+        return self._offsets
+
+    def _refspectrum_bandflux(self, band):
+        if band not in self._bands:
+            raise ValueError('band not in local magnitude system')
+        i = self._bands.index(band)
+        standard = self._standards[i]
+        offset = self._offsets[i]
+
+        return 10.**(0.4 * offset) * standard.zpbandflux(band)
+
+    def __str__(self):
+        s = "LocalMagSystem {!r}:\n".format(self.name)
+
+        for i in range(len(self._bands)):
+            s += "  {!r}: system={!r}  offset={}\n".format(
+                self._bands[i].name,
+                self._standards[i].name,
+                self._offsets[i])
+        return s
 
 
 class SpectralMagSystem(MagSystem):


### PR DESCRIPTION
This supersedes #117 (commits squashed). Could still use some slight fixes, but this is the general idea. 

I've removed the CSP reader from this PR because it seems to dataset specific. It's still useful, but it might be better as part of kbarbary/sndatasets, e.g., the future `sncosmo.datasets` module.