### PR TITLE
Bandpass improvements

### DIFF
--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -128,15 +128,8 @@ def load_bandpass_microns(pkg_data_name, name=None):
 def load_bandpass_bessell(pkg_data_name, name=None):
     """Bessell bandpasses have (1/energy) transmission units."""
     fname = get_pkg_data_filename(pkg_data_name)
-    band = read_bandpass(fname, wave_unit=u.AA, trans_unit=u.erg**-1,
-                         name=name)
-
-    # We happen to know that Bessell bandpasses in file are arbitrarily
-    # scaled to have a peak of 1 photon / erg. Rescale here to a peak of
-    # 1 (unitless transmission) to be more similar to other bandpasses.
-    band.trans /= np.max(band.trans)
-
-    return band
+    return read_bandpass(fname, wave_unit=u.AA, trans_unit=u.erg**-1,
+                         normalize=True, name=name)
 
 
 def tophat_bandpass(ctr, width, name=None):

--- a/sncosmo/tests/test_models.py
+++ b/sncosmo/tests/test_models.py
@@ -42,7 +42,9 @@ class TestTimeSeriesSource:
 
         # Correct answer
         b = sncosmo.get_bandpass("bessellb")
-        ans = np.sum(b.trans * b.wave * b.dwave) / sncosmo.models.HC_ERG_AA
+        dwave = np.gradient(b.wave)
+        ans = np.sum(b.trans * b.wave * dwave) / sncosmo.models.HC_ERG_AA
+
         assert_approx_equal(ans, f)
 
     def test_bandflux_shapes(self):


### PR DESCRIPTION
This PR does two things to address #99:
- Make bandpasses callable continuous functions. One can still access `band.wave` and `band.trans`
  to get the arrays defining the bandpass. However one can now also get the
  the transmission at arbitrary wavelengths, using `band(wave)`. This means that bandpasses can
  be defined with arbitrary spacing without having a big effect on the speed and accuracy of synthetic photometry.
  
  Along with this change, there is a new option when initializing a Bandpass: `trunc_level`, which truncates out-of-band transmission. This is useful for working with bandpass data that is defined over a very wide range (and where most of the transmission is very close to zero). This lays the groundwork for using bandpass data as provided, without having to preprocess it.
- In Model.bandflux(), the above Bandpass capability is now used to sample the bandpass at a regular interval (of ~5 angstroms, for now), regardless of native bandpass sampling.
