### PR TITLE
Drop python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,13 @@ addons:
 env:
     global:
         # Set defaults to avoid repeating in most cases.
-        - NUMPY_VERSION=1.9
-        - ASTROPY_VERSION=1.0
+        - NUMPY_VERSION=1.10
+        - ASTROPY_VERSION=1.1
         - OPTIONAL_DEPS=true
         - MAIN_CMD='python setup.py'
 
     matrix:
-        - PYTHON_VERSION=2.6 SETUP_CMD='egg_info'
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
 
@@ -53,30 +51,28 @@ matrix:
 
         # Try all python versions
         - os: linux
-          env: PYTHON_VERSION=2.6 SETUP_CMD='test'
-        - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test'
         - os: linux
-          env: PYTHON_VERSION=3.3 SETUP_CMD='test'
-        - os: linux
           env: PYTHON_VERSION=3.4 SETUP_CMD='test'
+        - os: linux
+          env: PYTHON_VERSION=3.5 SETUP_CMD='test'
 
         # Try astropy dev version
         - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=dev SETUP_CMD='test'
         - os: linux
-          env: PYTHON_VERSION=3.4 ASTROPY_VERSION=dev SETUP_CMD='test'
+          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=dev SETUP_CMD='test'
 
         # Try disabling optional dependencies
         - os: linux
           env: PYTHON_VERSION=2.7 OPTIONAL_DEPS=false SETUP_CMD='test'
         - os: linux
-          env: PYTHON_VERSION=3.4 OPTIONAL_DEPS=false SETUP_CMD='test'
+          env: PYTHON_VERSION=3.5 OPTIONAL_DEPS=false SETUP_CMD='test'
 
         # Try older numpy versions & astropy versions
         # (conda only has builds for np18 and later for astropy 1.0) 
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 ASTROPY_VERSION=0.4 SETUP_CMD='test'
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 ASTROPY_VERSION=0.4 SETUP_CMD='test'
 
         # Do a PEP8 test
         - os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,14 +13,10 @@ environment:
 
   matrix:
 
-      # We test Python 2.6 and 3.4 because 2.6 is most likely to have issues in
-      # Python 2 (if 2.6 passes, 2.7 virtually always passes) and Python 3.4 is
-      # the latest Python 3 release.
-
-      - PYTHON_VERSION: "2.6"
-        NUMPY_VERSION: "1.9.1"
-      - PYTHON_VERSION: "3.4"
-        NUMPY_VERSION: "1.9.1"
+      - PYTHON_VERSION: "2.7"
+        NUMPY_VERSION: "1.10.4"
+      - PYTHON_VERSION: "3.5"
+        NUMPY_VERSION: "1.10.4"
 
 platform:
     -x64

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,7 +2,7 @@
 Installation
 ************
 
-SNCosmo works on Python 2.6, 2.7 and Python 3.3+ and requires the
+SNCosmo works on Python 2.7 and Python 3.3+ and requires the
 following standard scientific python packages: `NumPy
 <http://www.numpy.org/>`_, `SciPy <http://www.scipy.org/>`_ and
 AstroPy_.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ else:
 builtins._ASTROPY_SETUP_ = True
 
 from astropy_helpers.setup_helpers import (
-    register_commands, adjust_compiler, get_debug_option, get_package_info)
+    register_commands, get_debug_option, get_package_info)
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
@@ -64,10 +64,6 @@ if not RELEASE:
 # invoking any other functionality from distutils since it can potentially
 # modify distutils' behavior.
 cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
-
-# Adjust the compiler in case the default on this platform is to use a
-# broken one.
-adjust_compiler(PACKAGENAME)
 
 # Freeze build information in version.py
 generate_version_py(PACKAGENAME, VERSION, RELEASE,

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -12,13 +12,13 @@ import warnings
 import os
 from os.path import join
 import codecs
+from collections import OrderedDict
 
 import numpy as np
 from astropy import wcs, units as u
 from astropy.io import ascii, fits
-from astropy.config import ConfigurationItem, get_cache_dir
+from astropy.config import ConfigItem, get_cache_dir
 from astropy.extern import six
-from astropy.utils import OrderedDict
 from astropy.utils.data import get_pkg_data_filename
 
 from . import registry

--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -3,10 +3,10 @@ from __future__ import division, print_function
 from warnings import warn
 import copy
 import time
+from collections import OrderedDict as odict
 
 import numpy as np
 from scipy.interpolate import InterpolatedUnivariateSpline as Spline1d
-from astropy.utils import OrderedDict as odict
 from astropy.extern import six
 
 from .photdata import standardize_data, normalize_data

--- a/sncosmo/io.py
+++ b/sncosmo/io.py
@@ -8,9 +8,9 @@ import os
 import sys
 import re
 import json
+from collections import OrderedDict as odict
 
 import numpy as np
-from astropy.utils import OrderedDict as odict
 from astropy.table import Table
 from astropy.io import fits
 from astropy import wcs

--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -4,6 +4,7 @@
 
 import abc
 import os
+from collections import OrderedDict as odict
 from copy import copy as cp
 from textwrap import dedent
 from math import ceil
@@ -13,7 +14,6 @@ import numpy as np
 from scipy.interpolate import (InterpolatedUnivariateSpline as Spline1d,
                                RectBivariateSpline as Spline2d,
                                splmake, spleval)
-from astropy.utils import OrderedDict as odict
 from astropy.utils.misc import isiterable
 from astropy import (cosmology, units as u, constants as const)
 from astropy.extern import six

--- a/sncosmo/photdata.py
+++ b/sncosmo/photdata.py
@@ -3,9 +3,9 @@
 from __future__ import division
 
 import math
+from collections import OrderedDict as odict
 
 import numpy as np
-from astropy.utils import OrderedDict as odict
 from astropy.table import Table
 from astropy.extern import six
 

--- a/sncosmo/registry.py
+++ b/sncosmo/registry.py
@@ -2,7 +2,7 @@
 """The sncosmo registry is used to load and return instances in memory
 based on string identifiers."""
 
-from astropy.utils import OrderedDict
+from collections import OrderedDict
 from astropy.extern import six
 
 __all__ = ['register_loader', 'register']

--- a/sncosmo/simulation.py
+++ b/sncosmo/simulation.py
@@ -5,13 +5,13 @@ from __future__ import print_function
 import sys
 import math
 import copy
+from collections import OrderedDict as odict
 
 import numpy as np
 from numpy import random
 from scipy.interpolate import InterpolatedUnivariateSpline as Spline1d
 from astropy.table import Table
 from astropy.cosmology import FlatLambdaCDM
-from astropy.utils import OrderedDict as odict
 from astropy.extern.six.moves import range
 
 __all__ = ['zdist', 'realize_lcs']

--- a/sncosmo/snanaio.py
+++ b/sncosmo/snanaio.py
@@ -1,6 +1,7 @@
+from collections import OrderedDict as odict
+
 import numpy as np
 
-from astropy.utils import OrderedDict as odict
 from astropy.io import fits
 from astropy.table import Table, vstack
 from astropy.extern import six

--- a/sncosmo/spectral.py
+++ b/sncosmo/spectral.py
@@ -3,10 +3,11 @@
 import abc
 import math
 from copy import deepcopy
+from collections import OrderedDict
 
 import numpy as np
 
-from astropy.utils import OrderedDict, lazyproperty
+from astropy.utils import lazyproperty
 from astropy.io import ascii
 import astropy.units as u
 import astropy.constants as const


### PR DESCRIPTION
The dev version of astropy (v1.2) no longer supports Python 2.6. Now sncosmo doesn't either.