### PR TITLE
Separate registries for Bandpass, MagSystem, Source

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -16,7 +16,7 @@ export PIP_INSTALL="pip install --no-deps --no-use-wheel"
 
 # Now set up shortcut to conda install command to make sure the Python and Numpy
 # versions are always explicitly specified.
-export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
+export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION"
 
 # EGG_INFO
 if [[ $SETUP_CMD == egg_info ]]
@@ -32,7 +32,7 @@ then
 fi
 
 # CORE DEPENDENCIES (besides astropy)
-$CONDA_INSTALL pip pytest Cython jinja2 psutil scipy
+$CONDA_INSTALL pip pytest Cython jinja2 psutil
 
 # ASTROPY
 if [[ $ASTROPY_VERSION == dev ]]

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
         # Set defaults to avoid repeating in most cases.
         - NUMPY_VERSION=1.10
         - ASTROPY_VERSION=1.1
+        - SCIPY_VERSION=0.17
         - OPTIONAL_DEPS=true
         - MAIN_CMD='python setup.py'
 
@@ -72,7 +73,7 @@ matrix:
         # Try older numpy versions & astropy versions
         # (conda only has builds for np18 and later for astropy 1.0) 
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 ASTROPY_VERSION=0.4 SETUP_CMD='test'
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SCIPY_VERSION=0.14 ASTROPY_VERSION=0.4 SETUP_CMD='test'
 
         # Do a PEP8 test
         - os: linux

--- a/docs/_helpers/bandpass_page.py
+++ b/docs/_helpers/bandpass_page.py
@@ -3,12 +3,12 @@ and save it to this module's docstring for the purpose of including in
 sphinx documentation via the automodule directive."""
 
 from astropy.extern import six
-from sncosmo import registry, Bandpass, get_bandpass
+from sncosmo.spectral import _BANDPASSES
 
 # string.ascii_letters in py3
 ASCII_LETTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
-bandpass_meta = registry.get_loaders_metadata(Bandpass)
+bandpass_meta = _BANDPASSES.get_loaders_metadata()
 table_delim = "  ".join([11 * '=', 80 * '=', 14 * '=', 8 * '=', 12 * '='])
 table_colnames = ("{0:11}  {1:80}  {2:14}  {3:8}  {4:12}"
                   .format('Name', 'Description', 'Reference', 'Data URL',

--- a/docs/_helpers/bandpass_plot.py
+++ b/docs/_helpers/bandpass_plot.py
@@ -1,7 +1,7 @@
 """Helper function to plot a set of bandpasses in sphinx docs."""
 from __future__ import division
 
-from sncosmo import registry, Bandpass, get_bandpass
+import sncosmo
 from matplotlib import rc
 from matplotlib import pyplot as plt
 
@@ -11,7 +11,7 @@ def plot_bandpass_set(setname):
 
     rc("font", family="serif")
 
-    bandpass_meta = registry.get_loaders_metadata(Bandpass)
+    bandpass_meta = sncosmo.spectral._BANDPASSES.get_loaders_metadata()
 
     fig = plt.figure(figsize=(9, 3))
     ax = plt.axes()
@@ -20,7 +20,7 @@ def plot_bandpass_set(setname):
     for m in bandpass_meta:
         if m['filterset'] != setname:
             continue
-        b = get_bandpass(m['name'])
+        b = sncosmo.get_bandpass(m['name'])
         ax.plot(b.wave, b.trans, label=m['name'])
         nbands += 1
 

--- a/docs/_helpers/magsystem_page.py
+++ b/docs/_helpers/magsystem_page.py
@@ -5,7 +5,7 @@ sphinx documentation via the automodule directive."""
 import string
 
 from astropy.extern import six
-from sncosmo import registry, MagSystem
+from sncosmo.spectral import _MAGSYSTEMS
 
 
 lines = ['',
@@ -15,7 +15,7 @@ lines = ['',
 lines.append(lines[1])
 
 urlnums = {}
-for m in registry.get_loaders_metadata(MagSystem):
+for m in _MAGSYSTEMS.get_loaders_metadata():
 
     urllink = ''
     description = ''

--- a/docs/_helpers/source_page.py
+++ b/docs/_helpers/source_page.py
@@ -5,7 +5,7 @@ sphinx documentation via the automodule directive."""
 import string
 
 from astropy.extern import six
-from sncosmo import registry, Source
+from sncosmo.models import _SOURCES
 
 
 lines = [
@@ -19,7 +19,7 @@ lines.append(lines[1])
 urlnums = {}
 allnotes = []
 allrefs = []
-for m in registry.get_loaders_metadata(Source):
+for m in _SOURCES.get_loaders_metadata():
 
     reflink = ''
     urllink = ''

--- a/sncosmo/_registry.py
+++ b/sncosmo/_registry.py
@@ -1,0 +1,200 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from collections import OrderedDict
+
+from astropy.extern import six
+
+class Registry(object):
+    """Connect strings to instances and loaders."""
+
+    def __init__(self):
+        self._loaders = OrderedDict()
+        self._instances = OrderedDict()
+
+    def register_loader(self, name, func, args=None, version=None, meta=None,
+                        force=False):
+        """Register a data reading function.
+
+        Parameters
+        ----------
+        name : str
+            The data identifier.
+        func : callable
+            The function to read in the data. Must accept a name and version
+            keyword argument.
+        args : list, optional
+            Arguments to pass to the function. Default is an empty list.
+        version : str, optional
+            Sub-version of name, if desired. Use formats such as ``'1'``,
+            ``'1.0'``, ``'1.0.0'``, etc. Default is `None`.
+        force : bool, optional
+            Whether to override any existing function if already present.
+        meta : dict, optional
+            Metadata describing this loader. Default is an empty dictionary.
+        """
+
+        if args is None:
+            args = []
+        if meta is None:
+            meta = {}
+
+        name = name.lower()  # names are stored in all-lowercase.
+        key = (name, version)
+
+        # check if key already exists in the registry
+        if key in self._loaders and not force:
+            versionstr = \
+                "" if version is None else " (version='{0:s}')".format(version)
+            raise Exception("Loader for {0:s} named '{1:s}'{2:s} is already "
+                            "defined. Use force=True to override."
+                            .format(data_class.__name__, name, versionstr))
+
+        self._loaders[key] = func, args, meta
+
+    def register(self, instance, name=None, force=False):
+        """Register a class instance.
+
+        Parameters
+        ----------
+        instance : object
+            The object to be registered.
+        name : str, optional
+            Identifier. If `None`, the name is taken from the `name` attribute
+            of the instance, if it exists and is a string.
+        force : bool, optional
+            Whether to override any existing instance of the same name.
+            Note: this may not play well with versioned instances.
+        """
+
+        if name is None:
+            try:
+                name = instance.name
+            except AttributeError:
+                raise ValueError("name not given and instance has no 'name' "
+                                 "attribute")
+            if not isinstance(name, six.string_types):
+                raise ValueError("name attribute of {0!r:s} is not a string.")
+
+        name = name.lower()
+        key = (name, None)
+
+        # check if key is already in instances or loaders:
+        if (key in self._instances or key in self._loaders) and not force: 
+            raise Exception("{0:s} already in registry. Use force=True"
+                            " to override.".format(name))
+
+        self._instances[key] = instance
+
+    def retrieve(self, name, version=None):
+        """Retrieve an instance from a registered identifier.
+
+        Parameters
+        ----------
+        name : str
+            Identifier of the specific instance. `name` is case-independent
+            (internally names are stored as lowercase).
+        version : str
+            Sub-identifier. If `None`, default to highest or only version.
+
+        Returns
+        -------
+        instance
+
+        Notes
+        -----
+        **Precedence** The following are tried in this order:
+
+        1. If ``name`` is already loaded in the registry, that instance is
+           returned.
+        2. If there is a loader defined for (`data_class`, `name`), it is used
+           to create an instance, save it to the registry and return it.
+        3. An Exception is raised listing the available registered names.
+
+        **Versioning** There is support for multiple versions of data for the
+        same `name`.
+
+        1. If ``version`` is specified, the registry and its loaders are
+           searched for ``(name, version)``.
+        2. If ``version`` is not specified but there are registered loaders for
+           ``(name, version)``, the latest version is used, and both
+           ``(name, None)`` and ``(name, version)`` are saved to the registry.
+           "Latest" is defined by string comparision.
+
+        """
+
+        name = name.lower()
+        key = (name, version)
+
+        # Try to retrieve from instances
+        try:
+            return self._instances[key]
+        except KeyError:
+            pass
+
+        # Try to retrieve from the loaders.
+        if key in self._loaders:
+            func, args, meta = self._loaders[key]
+            if version is None:
+                self._instances[key] = func(*args, name=name)
+            else:
+                self._instances[key] = func(*args, name=name, version=version)
+            return self._instances[key]
+
+        # If we got this far and the version is not specified,
+        # find the latest version and try to load it.
+        if version is None:
+            latest_version = None
+            for regkey in self._loaders.keys():
+                if (name == regkey[0] and (latest_version is None or
+                                           regkey[1] > latest_version)):
+                    latest_version = regkey[1]
+            if latest_version is not None:
+                regkey = (name, latest_version)
+                func, args, meta = self._loaders[regkey]
+                self._instances[regkey] = func(*args, name=name,
+                                               version=latest_version)
+                self._instances[key] = self._instances[regkey]
+                return self._instances[key]
+
+        # At this point we will raise an exception and all the following
+        # is to make it more informative.
+
+        # all names regardless of version:
+        registered_names = set(k[0] for k in self._loaders)
+        registered_names.update(set(k[0] for k in self._instances))
+
+        # If we don't have the name regardless of version:
+        if version is None or name not in registered_names:
+            raise Exception(
+                "{0!r} not in registry. Registered names: '{1}'"
+                .format(name, "', '".join(registered_names)))
+
+        # If version was specified but we don't have that specific version:
+        registered_versions = [regkey[1] for regkey in self._loaders
+                               if name == regkey[0]]
+        raise Exception(
+            "No {0!r} with version='{1:s}' in registry. Registered"
+            " versions: '{2:s}'".format(name, version,
+                                        "', '".join(registered_versions)))
+
+    def get_loaders_metadata(self):
+        """Return the metadata of all registered loaders.
+
+        Returns
+        -------
+        loadermeta : list of dict
+            Each item in the list is a dictionary containing a 'name'
+            keyword, a 'version' keyword (if applicable), and the metadata
+            keywords for the given loader.
+        """
+
+        result = []
+        for key, loader in six.iteritems(self._loaders):
+            name, version = key
+            m = {'name': name}
+            if version is not None:
+                m['version'] = version
+            m.update(loader[2])
+            result.append(m)
+
+        return result

--- a/sncosmo/_registry.py
+++ b/sncosmo/_registry.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 from astropy.extern import six
 
+
 class Registry(object):
     """Connect strings to instances and loaders."""
 
@@ -79,7 +80,7 @@ class Registry(object):
         key = (name, None)
 
         # check if key is already in instances or loaders:
-        if (key in self._instances or key in self._loaders) and not force: 
+        if (key in self._instances or key in self._loaders) and not force:
             raise Exception("{0:s} already in registry. Use force=True"
                             " to override.".format(name))
 

--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -20,7 +20,7 @@ from astropy.extern import six
 
 from .io import read_griddata_ascii, read_griddata_fits
 
-from . import registry
+from ._registry import Registry
 from .spectral import get_bandpass, get_magsystem, Bandpass, HC_ERG_AA
 try:
     # Not guaranteed available at setup time
@@ -32,6 +32,8 @@ except ImportError:
 __all__ = ['get_source', 'Source', 'TimeSeriesSource', 'StretchSource',
            'SALT2Source', 'MLCS2k2Source', 'Model',
            'PropagationEffect', 'CCM89Dust', 'OD94Dust', 'F99Dust']
+
+_SOURCES = Registry()
 
 
 def _check_for_fitpack_error(e, a, name):
@@ -86,7 +88,7 @@ def get_source(name, version=None, copy=False):
         else:
             return name
     else:
-        return cp(registry.retrieve(Source, name, version=version))
+        return cp(_SOURCES.retrieve(name, version=version))
 
 
 def _bandflux(model, band, time_or_phase, zp, zpsys):

--- a/sncosmo/registry.py
+++ b/sncosmo/registry.py
@@ -1,14 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""The sncosmo registry is used to load and return instances in memory
-based on string identifiers."""
+"""Public interface functions for registering and retrieving from registries"""
 
-from collections import OrderedDict
-from astropy.extern import six
+from . import models
+from . import spectral
 
 __all__ = ['register_loader', 'register']
 
-_loaders = OrderedDict()
-_instances = OrderedDict()
+
+def _get_registry(data_class):
+    if issubclass(data_class, spectral.Bandpass):
+        return spectral._BANDPASSES
+    elif issubclass(data_class, spectral.MagSystem):
+        return spectral._MAGSYSTEMS
+    elif issubclass(data_class, models.Source):
+        return models._SOURCES
+
+    raise ValueError("No registry for type: {}".format(data_class))
 
 
 def register_loader(data_class, name, func, args=None,
@@ -38,31 +45,8 @@ def register_loader(data_class, name, func, args=None,
         Metadata describing this loader. Default is an empty dictionary.
     """
 
-    if args is None:
-        args = []
-    if meta is None:
-        meta = {}
-
-    # Convert name to lowercase. The registry stores names in all-lowercase.
-    name = name.lower()
-
-    # define the key
-    if version is None:
-        key = (data_class, name)
-    else:
-        key = (data_class, name, version)
-
-    # Add the loader to the registry if it is not already there.
-    if key not in _loaders or force:
-        _loaders[key] = func, args, meta
-    else:
-        if version is not None:
-            versionstr = " (version='{0:s}')".format(version)
-        else:
-            versionstr = ""
-        raise Exception("Loader for {0:s} named '{1:s}'{2:s} is already "
-                        "defined. Use force=True to override."
-                        .format(data_class.__name__, name, versionstr))
+    _get_registry(data_class).register_loader(
+        name, func, args=args, version=version, meta=meta, force=force)
 
 
 def register(instance, name=None, data_class=None, force=False):
@@ -87,27 +71,10 @@ def register(instance, name=None, data_class=None, force=False):
         may not play well with versioned instances.
     """
 
-    if name is None:
-        try:
-            name = instance.name
-        except AttributeError:
-            raise ValueError("name not given and instance has no 'name' "
-                             "attribute")
-        if not isinstance(name, six.string_types):
-            raise ValueError("name attribute of {0!r:s} is not a string.")
-
     if data_class is None:
         data_class = instance.__class__
 
-    name = name.lower()
-    key = (data_class, name)
-
-    already_present = (key in _instances) or (key in _loaders)
-    if not already_present or force:
-        _instances[key] = instance
-    else:
-        raise Exception("{0:s} named {1:s} already in registry. Use force=True"
-                        " to override.".format(data_class.__name__, name))
+    _get_registry(data_class).register(instance, name=name, force=force)
 
 
 def retrieve(data_class, name, version=None):
@@ -156,95 +123,4 @@ def retrieve(data_class, name, version=None):
 
     """
 
-    if isinstance(name, data_class):
-        return name
-
-    # Try to retrieve from the instances assuming `name` is lowercase.
-    if version is None:
-        key = (data_class, name)
-    else:
-        key = (data_class, name, version)
-    try:
-        return _instances[key]
-    except KeyError:
-        pass
-
-    # Try to convert name to lowercase first.
-    name = name.lower()
-    if version is None:
-        key = (data_class, name)
-    else:
-        key = (data_class, name, version)
-    try:
-        return _instances[key]
-    except KeyError:
-        pass
-
-    # Try to retrieve from the loaders.
-    if key in _loaders:
-        func, args, meta = _loaders[key]
-        if version is None:
-            _instances[key] = func(*args, name=name)
-        else:
-            _instances[key] = func(*args, name=name, version=version)
-        return _instances[key]
-
-    # If version not specified, find the latest version and try to load it.
-    if version is None:
-        latest_version = None
-        for regkey in _loaders.keys():
-            if (key == regkey[0:2] and (latest_version is None or
-                                        regkey[2] > latest_version)):
-                latest_version = regkey[2]
-        if latest_version is not None:
-            regkey = (key[0], key[1], latest_version)
-            func, args, meta = _loaders[regkey]
-            _instances[regkey] = func(*args, name=name, version=latest_version)
-            _instances[key] = _instances[regkey]
-            return _instances[key]
-
-    # At this point we will raise an exception.
-    registered_names = [regkey[1] for regkey in _loaders.keys()
-                        if regkey[0] is data_class]
-    for regkey in _instances.keys():
-        if regkey[0] is data_class and regkey[1] not in registered_names:
-            registered_names.append(regkey[1])
-
-    if version is None or name not in registered_names:
-        raise Exception(
-            "No {0} named {1!r} in registry. Registered names: '{2}'"
-            .format(data_class.__name__, name, "', '".join(registered_names)))
-
-    registered_versions = [regkey[2] for regkey in _loaders.keys()
-                           if key[0:2] == regkey[0:2]]
-    raise Exception(
-        "No {0:s} named '{1:s}' with version='{2:s}' in registry. Registered"
-        " versions: '{3:s}'".format(data_class.__name__, name, version,
-                                    "', '".join(registered_versions)))
-
-
-def get_loaders_metadata(data_class):
-    """Return the metadata of all registered loaders for a given class.
-
-    Parameters
-    ----------
-    data_class : classobj
-
-    Returns
-    -------
-    loadermeta : list of dict
-        Each item in the list is a dictionary containing a 'name'
-        keyword, a 'version' keyword (if applicable), and the metadata
-        keywords for the given loader.
-    """
-
-    loaders_metadata = []
-    for lkey, loader in six.iteritems(_loaders):
-        if lkey[0] is not data_class:
-            continue
-        m = {'name': lkey[1]}
-        if len(lkey) > 2:
-            m['version'] = lkey[2]
-        m.update(loader[2])
-        loaders_metadata.append(m)
-    return loaders_metadata
+    _get_registry(data_class).retrieve(name, version=version)

--- a/sncosmo/spectral.py
+++ b/sncosmo/spectral.py
@@ -24,6 +24,7 @@ HC_ERG_AA = const.h.cgs.value * const.c.to(u.AA / u.s).value
 _BANDPASSES = Registry()
 _MAGSYSTEMS = Registry()
 
+
 def get_bandpass(name):
     """Get a Bandpass from the registry by name."""
     if isinstance(name, Bandpass):

--- a/sncosmo/spectral.py
+++ b/sncosmo/spectral.py
@@ -13,7 +13,7 @@ import astropy.units as u
 import astropy.constants as const
 from astropy import cosmology
 
-from . import registry
+from ._registry import Registry
 
 __all__ = ['get_bandpass', 'get_magsystem', 'read_bandpass', 'Bandpass',
            'Spectrum', 'MagSystem', 'SpectralMagSystem', 'ABMagSystem',
@@ -21,15 +21,21 @@ __all__ = ['get_bandpass', 'get_magsystem', 'read_bandpass', 'Bandpass',
 
 HC_ERG_AA = const.h.cgs.value * const.c.to(u.AA / u.s).value
 
+_BANDPASSES = Registry()
+_MAGSYSTEMS = Registry()
 
 def get_bandpass(name):
     """Get a Bandpass from the registry by name."""
-    return registry.retrieve(Bandpass, name)
+    if isinstance(name, Bandpass):
+        return name
+    return _BANDPASSES.retrieve(name)
 
 
 def get_magsystem(name):
-    """Get a MagSystem from the registery by name."""
-    return registry.retrieve(MagSystem, name)
+    """Get a MagSystem from the registry by name."""
+    if isinstance(name, MagSystem):
+        return name
+    return _MAGSYSTEMS.retrieve(name)
 
 
 def read_bandpass(fname, fmt='ascii', wave_unit=u.AA,

--- a/sncosmo/tests/test_io.py
+++ b/sncosmo/tests/test_io.py
@@ -38,6 +38,7 @@ def test_read_griddata_ascii():
     f.seek(0)
 
     x0, x1, y = sncosmo.read_griddata_ascii(f)
+    f.close()
 
     assert_allclose(x0, np.array([0., 1.]))
     assert_allclose(x1, np.array([0., 1., 2.]))
@@ -55,6 +56,7 @@ def test_write_griddata_ascii():
     # Read it back
     f.seek(0)
     x0_in, x1_in, y_in = sncosmo.read_griddata_ascii(f)
+    f.close()
     assert_allclose(x0_in, x0)
     assert_allclose(x1_in, x1)
     assert_allclose(y_in, y)
@@ -95,6 +97,8 @@ def test_griddata_fits():
     # Read it back
     f.seek(0)
     x0_in, x1_in, x2_in, y_in = sncosmo.read_griddata_fits(f)
+    f.close()
+
     assert_allclose(x0_in, x0)
     assert_allclose(x1_in, x1)
     assert_allclose(x2_in, x2)

--- a/sncosmo/tests/test_models.py
+++ b/sncosmo/tests/test_models.py
@@ -103,6 +103,12 @@ class TestSALT2Source:
                                           lcrv01file=files[5],
                                           cdfile=cdfile)
 
+        for f in files:
+            f.close()
+        cdfile.close()
+        clfile.close()
+
+
         def test_bandflux_rcov(self):
 
             # component 1:

--- a/sncosmo/tests/test_models.py
+++ b/sncosmo/tests/test_models.py
@@ -108,7 +108,6 @@ class TestSALT2Source:
         cdfile.close()
         clfile.close()
 
-
         def test_bandflux_rcov(self):
 
             # component 1:


### PR DESCRIPTION
This puts all the registry machinery into a `Registry` class. Then, there are three separate `Registry` objects instantiated for storing `Bandpass`es, `MagSystem`s and `Source`s. The public API remains the same.

This should address #132.