### PR TITLE
Make `mcmc_lc` accept log priors, not prior pdfs, to avoid underflow

### DIFF
--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -784,9 +784,9 @@ def mcmc_lc(data, model, vparam_names, bounds=None, priors=None,
         the maximum bound is such that the earliest phase of the model
         lines up with the latest data point.
     priors : `dict`, optional
-        Prior probability functions. Keys are parameter names, values are
-        functions that return probability given the parameter value.
-        The default prior is a flat distribution.
+        Prior probability functions. Keys are parameter names, values
+        are functions that return the log probability given the
+        parameter value.  The default prior is a flat distribution.
     guess_amplitude : bool, optional
         Whether or not to guess the amplitude from the data. If false, the
         current model amplitude is taken as the initial value. Only has an
@@ -922,7 +922,7 @@ def mcmc_lc(data, model, vparam_names, bounds=None, priors=None,
         logp = -0.5 * _chisq(data, model, modelcov=modelcov)
 
         for i, func in idxpriors:
-            logp += math.log(func(parameters[i]))
+            logp += func(parameters[i])
 
         return logp
 


### PR DESCRIPTION
This PR alters the interface of the `mcmc_lc` method, making its `priors` argument take a dictionary of functions that return the log prior, rather than the prior pdf. Reasons for doing this:
- computing the log probability directly is often cheaper than computing the pdf and then taking the log 
- it avoids underflow (no situations where an exception will be raised by trying to take the log of 0)
