### PR TITLE
deprecate SFD98Map and get_ebv_from_map

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,11 @@ numbers.
 v1.4.0 (unreleased)
 ===================
 
+- ``SFD98Map`` and ``get_ebv_from_map`` deprecated in favor of separate package
+  `sfdmap <http://github.com/kbarbary/sfdmap>`_ which has vastly improved
+  performance (200x faster) for the typical case of scalar coordinates in
+  ICRS frame.
+
 - Cython implementation of extinction functions has been factored out into
   a separate Python module called ``extinction``, which is now a dependency.
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -218,34 +218,22 @@ frame) and ``'obs'`` (observer frame).
 A typical use pattern is to get an estimate of the amount of Milky Way
 dust at the location of the supernova from a dust map, and then to fix
 that amount of dust in the model.  The following example illustrates
-how to do this using the Schlegel, Finkbeiner and Davis (1998) dust map.
+how to do this using the Schlegel, Finkbeiner and Davis (1998) dust map
+with the `sfdmap <http://github.com/kbarbary/sfdmap>`_ package.
 First, load the dust map (do this only once)::
 
-    >>> dustmap = sncosmo.SFD98Map("/path/to/dust/maps")
-
-.. note::
-
-   This supposes that you've downloaded the full resolution E(B-V)
-   maps from and placed them in the given directory ``"/path/to/dust/maps"``:
-   
-   - `SFD_dust_4096_ngp.fits <http://sncosmo.github.io/data/dust/SFD_dust_4096_ngp.fits>`_
-   
-   - `SFD_mask_4096_ngp.fits <http://sncosmo.github.io/data/dust/SFD_mask_4096_ngp.fits>`_
-   
-   - `SFD_dust_4096_sgp.fits <http://sncosmo.github.io/data/dust/SFD_dust_4096_sgp.fits>`_
-   
-   - `SFD_mask_4096_sgp.fits <http://sncosmo.github.io/data/dust/SFD_mask_4096_sgp.fits>`_
-
-   The directory can also be set in the
-   sncosmo configuration file, in which case you can just do
-   ``sncosmo.SFD98Map()``. See `~sncosmo.SFD98Map` for more details.
+    >>> import sfdmap
+  
+    >>> dustmap = sfdmap.SFDMap("/path/to/dust/maps")
 
 Now, for each SN you wish to fit, get the amount of dust at the SN location
 and set the ``mwebv`` model parameter appropriately. For example, if the SN is
 located at RA=42.8 degrees, Dec=0 degrees::
 
-  >>> ebv = dustmap.get_ebv((42.8, 0.))
+  >>> ebv = dustmap.ebv(42.8, 0.0)
+  
   >>> model.set(mwebv=ebv)
+
   >>> # proceed with fitting the other model parameters to the data.
 
 Note that we wish to *fix* the ``mwebv`` model parameter rather than

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -74,8 +74,6 @@ maps, and more.*
    read_griddata_fits
    write_griddata_ascii
    write_griddata_fits
-   get_ebv_from_map
-   SFD98Map
 
 .. _fitting-api:
 

--- a/sncosmo/__init__.py
+++ b/sncosmo/__init__.py
@@ -153,7 +153,6 @@ if not _ASTROPY_SETUP_:
     del os, ConfigItem, ConfigNamespace, update_default_config
 
     # Do all the necessary imports.
-    from .dustmap import *
     from .spectral import *
     from .models import *
     from .io import *
@@ -164,6 +163,7 @@ if not _ASTROPY_SETUP_:
     from .registry import *
 
     from . import registry  # deprecated in v1.2; use previous import.
+    from .deprecated import *
 
     # Register all the built-ins.
     from .builtins import *

--- a/sncosmo/deprecated.py
+++ b/sncosmo/deprecated.py
@@ -2,6 +2,7 @@
 """Extinction functions."""
 
 import os
+from warnings import warn
 
 import numpy as np
 from scipy.ndimage import map_coordinates
@@ -14,6 +15,16 @@ from astropy.utils import isiterable
 from sncosmo import conf
 
 __all__ = ['SFD98Map', 'get_ebv_from_map']
+
+
+warned = []
+
+
+def warn_once(name, msg):
+    global warned
+    if name not in warned:
+        warn(msg)
+        warned.append(name)
 
 
 class SFD98Map(object):
@@ -57,6 +68,12 @@ class SFD98Map(object):
     """
 
     def __init__(self, mapdir=None):
+
+        warn_once("SFD98Map",
+                  "`SFD98Map` and `get_ebv_from_map` are deprecated in "
+                  "sncosmo v1.4 and will be removed in sncosmo v2.0. "
+                  "Instead, use `SFDMap` and `ebv` from the sfdmap package; "
+                  "see http://github.com/kbarbary/sfdmap.")
 
         # Get mapdir
         if mapdir is None:


### PR DESCRIPTION
Deprecate `sncosmo.SFD98Map` and `sncosmo.get_ebv_from_map` in favor of the [sfdmap](http://github.com/kbarbary/sfdmap) package, which has vastly improved performance for scalar coordinates.

These will not actually be removed until sncosmo v2.0, following semantic versioning.
