### PR TITLE
Integration

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,8 +2,11 @@
 Version History
 ===============
 
-*Note:* SNCosmo uses `Semantic Versioning <http://semver.org>`_ for its version
-numbers.
+*Note:* SNCosmo uses `Semantic Versioning <http://semver.org>`_ for
+its version numbers. Specifically, this means that code written for
+sncosmo v1.0 will continue to work with any v1.x version. However,
+exact results may differ between versions in the 1.x series. (For
+example, due to changes in integration method.)
 
 v1.4.0 (unreleased)
 ===================
@@ -15,6 +18,17 @@ v1.4.0 (unreleased)
 
 - Cython implementation of extinction functions has been factored out into
   a separate Python module called ``extinction``, which is now a dependency.
+
+- ``Model.bandflux()`` and ``Source.bandflux()`` now integrate on a
+  fixed wavelength grid of 5 angstroms regardless of the wavelength
+  grid of the bandpass. This will result in small differences in
+  results from previous sncosmo versions.
+
+- The internal (publicly undocumented) ``Spectrum`` class now acts
+  more like ``Model``; in particular, its ``bandflux()`` method now
+  behaves the same way.  As ``Spectrum`` backs ``SpectralMagSystem``,
+  this makes the integration of models and zeropoints spectra more
+  consistent.
 
 - **[Bugfix]** Fixed missing import of ``math`` module in ``mcmc_lc()``
   when using the ``priors`` keyword. [Backported to v1.3.1]

--- a/sncosmo/_deprecated.py
+++ b/sncosmo/_deprecated.py
@@ -20,9 +20,13 @@ __all__ = ['SFD98Map', 'get_ebv_from_map']
 warned = []
 
 
-def warn_once(name, msg):
+def warn_once(name, depver, rmver, extra=None):
     global warned
     if name not in warned:
+        msg = ("{} is deprecated in sncosmo {} "
+               "and will be removed in sncosmo {}".format(name, depver, rmver))
+        if extra is not None:
+            msg += " " + extra
         warn(msg)
         warned.append(name)
 
@@ -69,11 +73,9 @@ class SFD98Map(object):
 
     def __init__(self, mapdir=None):
 
-        warn_once("SFD98Map",
-                  "`SFD98Map` and `get_ebv_from_map` are deprecated in "
-                  "sncosmo v1.4 and will be removed in sncosmo v2.0. "
-                  "Instead, use `SFDMap` and `ebv` from the sfdmap package; "
-                  "see http://github.com/kbarbary/sfdmap.")
+        warn_once("SFD98Map and get_ebv_from_map", "1.4", "2.0",
+                  "Instead, use `SFDMap` and `ebv` from the sfdmap package: "
+                  "http://github.com/kbarbary/sfdmap.")
 
         # Get mapdir
         if mapdir is None:

--- a/sncosmo/bandpasses.py
+++ b/sncosmo/bandpasses.py
@@ -174,10 +174,8 @@ class Bandpass(object):
 
     @lazyproperty
     def dwave(self):
-        warn_once("Bandpass.dwave",
-                  "Bandpass.dwave is deprecated in sncosmo v1.4 and will be "
-                  "removed in sncosmo v2.0. Use numpy.gradient(wave) with "
-                  "your own wavelength array.")
+        warn_once("Bandpass.dwave", "1.4", "2.0",
+                  "Use numpy.gradient(wave) with your own wavelength array.")
         return np.gradient(self.wave)
 
     @lazyproperty

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -130,15 +130,8 @@ def load_bandpass_microns(pkg_data_name, name=None):
 def load_bandpass_bessell(pkg_data_name, name=None):
     """Bessell bandpasses have (1/energy) transmission units."""
     fname = get_pkg_data_filename(pkg_data_name)
-    band = read_bandpass(fname, wave_unit=u.AA, trans_unit=u.erg**-1,
-                         name=name)
-
-    # We happen to know that Bessell bandpasses in file are arbitrarily
-    # scaled to have a peak of 1 photon / erg. Rescale here to a peak of
-    # 1 (unitless transmission) to be more similar to other bandpasses.
-    band.trans /= np.max(band.trans)
-
-    return band
+    return read_bandpass(fname, wave_unit=u.AA, trans_unit=u.erg**-1,
+                         normalize=True, name=name)
 
 
 def tophat_bandpass(ctr, width, name=None):

--- a/sncosmo/utils.py
+++ b/sncosmo/utils.py
@@ -11,6 +11,7 @@ import numpy as np
 from scipy import integrate, optimize
 from astropy.extern import six
 
+
 def dict_to_array(d):
     """Convert a dictionary of lists (or single values) to a structured
     numpy.ndarray."""


### PR DESCRIPTION
This PR makes `Model.bandflux()` and `Source.bandflux()` and `Spectrum.bandflux()` all integrate on a fixed wavelength grid, regardless of  the spacing of the wavelength grid in the bandpass itself. This makes the results less sensitive to the spacing that the bandpass is defined on. It also will enable evaluating the effect of the wavelength spacing using in integration.

Bandpasses are now effectively continuous 1-d functions with support between `Bandpass.minwave()` and `Bandpass.maxwave()`. (Linear interpolation is used between grid points.)