### PR TITLE
Towards better handling of photometric data

### DIFF
--- a/sncosmo/io.py
+++ b/sncosmo/io.py
@@ -16,7 +16,7 @@ from astropy.io import fits
 from astropy import wcs
 from astropy.extern import six
 
-from .photdata import dict_to_array
+from .utils import dict_to_array
 
 __all__ = ['read_lc', 'write_lc', 'load_example_data', 'read_griddata_ascii',
            'read_griddata_fits', 'write_griddata_ascii', 'write_griddata_fits']

--- a/sncosmo/photdata.py
+++ b/sncosmo/photdata.py
@@ -9,6 +9,7 @@ import math
 import numpy as np
 from astropy.table import Table
 
+from .utils import alias_map
 from .bandpasses import get_bandpass
 from .magsystems import get_magsystem
 
@@ -24,34 +25,6 @@ PHOTDATA_ALIASES = OrderedDict([
     ('zp', set(['zp', 'zpt', 'zeropoint', 'zero_point'])),
     ('zpsys', set(['zpsys', 'zpmagsys', 'magsys']))
     ])
-
-
-def alias_map(aliased, aliases):
-    """For each key in ``aliases``, find the item in ``aliased`` matching
-    exactly one of the corresponding items in ``aliases``. For example::
-
-        >>> aliases = {'a':set(['a', 'a_']), 'b':set(['b', 'b_'])}
-        >>> alias_map(['A', 'B_', 'foo'], aliases)
-        {'A': 'a', 'B_': 'b'}
-
-    """
-    lowered_to_orig = {key.lower(): key for key in aliased}
-    lowered = set(lowered_to_orig.keys())
-    mapping = {}
-    for key, key_aliases in aliases.items():
-        common = lowered & key_aliases
-        if len(common) == 0:
-            raise ValueError('no alias found for {!r} (possible '
-                             'case-independent aliases: {})'.format(
-                                 key,
-                                 ', '.join(repr(ka) for ka in key_aliases)))
-        if len(common) > 1:
-            raise ValueError('multiple aliases found for {!r}: {}'
-                             .format(key, ', '.join(repr(a) for a in common)))
-
-        mapping[lowered_to_orig[common.pop()]] = key
-
-    return mapping
 
 
 class PhotometricData(object):

--- a/sncosmo/photdata.py
+++ b/sncosmo/photdata.py
@@ -2,17 +2,21 @@
 """Convenience functions for photometric data."""
 from __future__ import division
 
+from collections import OrderedDict
+import copy
 import math
-from collections import OrderedDict as odict
 
 import numpy as np
 from astropy.table import Table
 
 from .bandpasses import get_bandpass
 from .magsystems import get_magsystem
-from .utils import dict_to_array
 
-_photdata_aliases = odict([
+# deprecated (private!) functions: make them available where they used to be
+from ._deprecated import standardize_data, normalize_data
+
+
+PHOTDATA_ALIASES = OrderedDict([
     ('time', set(['time', 'date', 'jd', 'mjd', 'mjdobs', 'mjd_obs'])),
     ('band', set(['band', 'bandpass', 'filter', 'flt'])),
     ('flux', set(['flux', 'f'])),
@@ -20,6 +24,138 @@ _photdata_aliases = odict([
     ('zp', set(['zp', 'zpt', 'zeropoint', 'zero_point'])),
     ('zpsys', set(['zpsys', 'zpmagsys', 'magsys']))
     ])
+
+
+def alias_map(aliased, aliases):
+    """For each key in ``aliases``, find the item in ``aliased`` matching
+    exactly one of the corresponding items in ``aliases``. For example::
+
+        >>> aliases = {'a':set(['a', 'a_']), 'b':set(['b', 'b_'])}
+        >>> alias_map(['A', 'B_', 'foo'], aliases)
+        {'A': 'a', 'B_': 'b'}
+
+    """
+    lowered_to_orig = {key.lower(): key for key in aliased}
+    lowered = set(lowered_to_orig.keys())
+    mapping = {}
+    for key, key_aliases in aliases.items():
+        common = lowered & key_aliases
+        if len(common) == 0:
+            raise ValueError('no alias found for {!r} (possible '
+                             'case-independent aliases: {})'.format(
+                                 key,
+                                 ', '.join(repr(ka) for ka in key_aliases)))
+        if len(common) > 1:
+            raise ValueError('multiple aliases found for {!r}: {}'
+                             .format(key, ', '.join(repr(a) for a in common)))
+
+        mapping[lowered_to_orig[common.pop()]] = key
+
+    return mapping
+
+
+class PhotometricData(object):
+    """Internal standardized representation of photometric data table.
+
+    Has attributes ``time``, ``band``, ``flux``, ``fluxerr``, ``zp`` and
+    ``zpsys``, which are all numpy arrays of the same length sorted by
+    ``time``. This is intended for use within sncosmo; its implementation
+    may change without warning in future versions.
+
+    Parameters
+    ----------
+    data : `~astropy.table.Table`, dict, `~numpy.ndarray`
+        Astropy Table, dictionary of arrays or structured numpy array
+        containing the "correct" column names.
+    """
+
+    def __init__(self, data):
+        # get column names in input data
+        if isinstance(data, Table):
+            colnames = data.colnames
+        elif isinstance(data, np.ndarray):
+            colnames = data.dtype.names
+        elif isinstance(data, dict):
+            colnames = data.keys()
+        else:
+            raise ValueError('unrecognized data type')
+
+        mapping = alias_map(colnames, PHOTDATA_ALIASES)
+
+        self.time = np.asarray(data[mapping['time']])
+        self.band = np.asarray(data[mapping['band']])
+        self.flux = np.asarray(data[mapping['flux']])
+        self.fluxerr = np.asarray(data[mapping['fluxerr']])
+        self.zp = np.asarray(data[mapping['zp']])
+        self.zpsys = np.asarray(data[mapping['zpsys']])
+
+        # ensure columns are equal length
+        if isinstance(data, dict):
+            if not (len(self.time) == len(self.band) == len(self.flux) ==
+                    len(self.fluxerr) == len(self.zp) == len(self.zpsys)):
+                raise ValueError("unequal column lengths")
+
+        # Sort by time, if necessary.
+        if not np.all(np.ediff1d(self.time) >= 0.0):
+            idx = np.argsort(self.time)
+            self.time = self.time[idx]
+            self.band = self.band[idx]
+            self.flux = self.flux[idx]
+            self.fluxerr = self.fluxerr[idx]
+            self.zp = self.zp[idx]
+            self.zpsys = self.zpsys[idx]
+
+    def __len__(self):
+        return len(self.time)
+
+    def __getitem__(self, key):
+        newdata = copy.copy(self)  # avoid going through __init__
+        newdata.time = self.time[key]
+        newdata.band = self.band[key]
+        newdata.flux = self.flux[key]
+        newdata.fluxerr = self.fluxerr[key]
+        newdata.zp = self.zp[key]
+        newdata.zpsys = self.zpsys[key]
+        return newdata
+
+    def normalized(self, zp=25., zpsys='ab'):
+        """Return a copy of the data with all flux and fluxerr values
+        normalized to the given zeropoint.
+        """
+
+        normmagsys = get_magsystem(zpsys)
+        factor = np.empty(len(self), dtype=np.float)
+
+        for b in set(self.band.tolist()):
+            idx = self.band == b
+            b = get_bandpass(b)
+
+            bandfactor = 10.**(0.4 * (zp - self.zp[idx]))
+            bandzpsys = self.zpsys[idx]
+            for ms in set(bandzpsys):
+                idx2 = bandzpsys == ms
+                ms = get_magsystem(ms)
+                bandfactor[idx2] *= (ms.zpbandflux(b) /
+                                     normmagsys.zpbandflux(b))
+            factor[idx] = bandfactor
+
+        newdata = copy.copy(self)
+        newdata.flux = factor * self.flux
+        newdata.fluxerr = factor * self.fluxerr
+        newdata.zp = np.full(len(self), zp, dtype=np.float64)
+        newdata.zpsys = np.full(len(self), zpsys, dtype=np.array(zpsys).dtype)
+
+        return newdata
+
+
+def photometric_data(data):
+    if isinstance(data, PhotometricData):
+        return data
+    else:
+        return PhotometricData(data)
+
+
+# Generate docstring: table of aliases
 
 # Descriptions for docstring only.
 _photdata_descriptions = {
@@ -30,6 +166,7 @@ _photdata_descriptions = {
     'zp': 'Zeropoint corresponding to flux',
     'zpsys': 'Magnitude system for zeropoint'
     }
+
 _photdata_types = {
     'time': 'float',
     'band': 'str',
@@ -39,112 +176,6 @@ _photdata_types = {
     'zpsys': 'str'
     }
 
-
-def standardize_data(data):
-    """Standardize photometric data by converting to a structured numpy array
-    with standard column names (if necessary) and sorting entries in order of
-    increasing time.
-
-    Parameters
-    ----------
-    data : `~astropy.table.Table`, `~numpy.ndarray` or dict
-
-    Returns
-    -------
-    standardized_data : `~numpy.ndarray`
-    """
-    if isinstance(data, Table):
-        data = np.asarray(data)
-
-    if isinstance(data, np.ndarray):
-        colnames = data.dtype.names
-
-        # Check if the data already complies with what we want
-        # (correct column names & ordered by date)
-        if (set(colnames) == set(_photdata_aliases.keys()) and
-                np.all(np.ediff1d(data['time']) >= 0.)):
-            return data
-
-    elif isinstance(data, dict):
-        colnames = data.keys()
-
-    else:
-        raise ValueError('Unrecognized data type')
-
-    # Create mapping from lowercased column names to originals
-    lower_to_orig = dict([(colname.lower(), colname) for colname in colnames])
-
-    # Set of lowercase column names
-    lower_colnames = set(lower_to_orig.keys())
-
-    orig_colnames_to_use = []
-    for aliases in _photdata_aliases.values():
-        i = lower_colnames & aliases
-        if len(i) != 1:
-            raise ValueError('Data must include exactly one column from {0} '
-                             '(case independent)'.format(', '.join(aliases)))
-        orig_colnames_to_use.append(lower_to_orig[i.pop()])
-
-    if isinstance(data, np.ndarray):
-        new_data = data[orig_colnames_to_use].copy()
-        new_data.dtype.names = list(_photdata_aliases.keys())
-
-    else:
-        new_data = odict()
-        for newkey, oldkey in zip(_photdata_aliases.keys(),
-                                  orig_colnames_to_use):
-            new_data[newkey] = data[oldkey]
-
-        new_data = dict_to_array(new_data)
-
-    # Sort by time, if necessary.
-    if not np.all(np.ediff1d(new_data['time']) >= 0.):
-        new_data.sort(order=['time'])
-
-    return new_data
-
-
-def normalize_data(data, zp=25., zpsys='ab'):
-    """Return a copy of the data with all flux and fluxerr values normalized
-    to the given zeropoint. Assumes data has already been standardized.
-
-    Parameters
-    ----------
-    data : `~numpy.ndarray`
-        Structured array.
-    zp : float
-    zpsys : str
-
-    Returns
-    -------
-    normalized_data : `~numpy.ndarray`
-    """
-
-    normmagsys = get_magsystem(zpsys)
-    factor = np.empty(len(data), dtype=np.float)
-
-    for b in set(data['band'].tolist()):
-        idx = data['band'] == b
-        b = get_bandpass(b)
-
-        bandfactor = 10.**(0.4 * (zp - data['zp'][idx]))
-        bandzpsys = data['zpsys'][idx]
-        for ms in set(bandzpsys):
-            idx2 = bandzpsys == ms
-            ms = get_magsystem(ms)
-            bandfactor[idx2] *= (ms.zpbandflux(b) / normmagsys.zpbandflux(b))
-
-        factor[idx] = bandfactor
-
-    normalized_data = odict([('time', data['time']),
-                             ('band', data['band']),
-                             ('flux', data['flux'] * factor),
-                             ('fluxerr', data['fluxerr'] * factor),
-                             ('zp', zp),
-                             ('zpsys', zpsys)])
-    return dict_to_array(normalized_data)
-
-# Generate docstring: table of aliases
 lines = [
     '',
     '  '.join([10 * '=', 60 * '=', 50 * '=', 50 * '=']),
@@ -153,8 +184,8 @@ lines = [
             'Description', 'Type')
     ]
 lines.append(lines[1])
-for colname in _photdata_aliases:
-    alias_list = ', '.join([repr(a) for a in _photdata_aliases[colname]])
+for colname in PHOTDATA_ALIASES:
+    alias_list = ', '.join([repr(a) for a in PHOTDATA_ALIASES[colname]])
     line = '{0:10}  {1:60}  {2:50}  {3:50}'.format(
         colname,
         alias_list,

--- a/sncosmo/plotting.py
+++ b/sncosmo/plotting.py
@@ -195,9 +195,9 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab',
     if data is None:
         bands = set(bands)
     elif bands is None:
-        bands = set(data['band'])
+        bands = set(data.band)
     else:
-        bands = set(data['band']) & set(bands)
+        bands = set(data.band) & set(bands)
 
     # Build figtext (including model parameters, if there is exactly 1 model).
     if errors is None:
@@ -275,8 +275,8 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab',
     # Global min and max of time axis.
     tmin, tmax = [], []
     if data is not None:
-        tmin.append(np.min(data['time']) - 10.)
-        tmax.append(np.max(data['time']) + 10.)
+        tmin.append(np.min(data.time) - 10.)
+        tmax.append(np.max(data.time) + 10.)
     for model in models:
         tmin.append(model.mintime())
         tmax.append(model.maxtime())
@@ -310,10 +310,10 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab',
 
         # Plot data if there are any.
         if data is not None:
-            mask = data['band'] == band
-            time = data['time'][mask]
-            flux = data['flux'][mask]
-            fluxerr = data['fluxerr'][mask]
+            mask = data.band == band
+            time = data.time[mask]
+            flux = data.flux[mask]
+            fluxerr = data.fluxerr[mask]
             ax.errorbar(time - toff, flux, fluxerr, ls='None',
                         color=bandcolor, marker='.', markersize=3.)
 

--- a/sncosmo/plotting.py
+++ b/sncosmo/plotting.py
@@ -11,7 +11,7 @@ from astropy.extern.six.moves import range
 from .models import Model
 from .bandpasses import get_bandpass
 from .magsystems import get_magsystem
-from .photdata import standardize_data, normalize_data
+from .photdata import photometric_data
 from .utils import format_value
 
 __all__ = ['plot_lc']
@@ -189,8 +189,7 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab',
 
     # Standardize and normalize data.
     if data is not None:
-        data = standardize_data(data)
-        data = normalize_data(data, zp=zp, zpsys=zpsys)
+        data = photometric_data(data).normalized(zp=zp, zpsys=zpsys)
 
     # Bands to plot
     if data is None:

--- a/sncosmo/tests/test_photdata.py
+++ b/sncosmo/tests/test_photdata.py
@@ -1,7 +1,0 @@
-from sncosmo.photdata import alias_map
-
-
-def test_alias_map():
-    mapping = alias_map(['A', 'B_', 'foo'],
-                        {'a': set(['a', 'a_']), 'b': set(['b', 'b_'])})
-    assert mapping == {'A': 'a', 'B_': 'b'}

--- a/sncosmo/tests/test_photdata.py
+++ b/sncosmo/tests/test_photdata.py
@@ -1,0 +1,7 @@
+from sncosmo.photdata import alias_map
+
+
+def test_alias_map():
+    mapping = alias_map(['A', 'B_', 'foo'],
+                        {'a': set(['a', 'a_']), 'b': set(['b', 'b_'])})
+    assert mapping == {'A': 'a', 'B_': 'b'}

--- a/sncosmo/tests/test_simulation.py
+++ b/sncosmo/tests/test_simulation.py
@@ -28,30 +28,40 @@ def test_zdist():
 def test_realize_lcs():
 
     # here's some completely made-up data:
-    obs = Table({'time': [10., 60., 110.],
-                 'band': ['desg', 'desr', 'desi'],
-                 'gain': [1., 1., 1.],
-                 'skynoise': [100., 100., 100.],
-                 'zp': [30., 30., 30.],
-                 'zpsys': ['ab', 'ab', 'ab']})
+    obs1 = Table({'time': [10., 60., 110.],
+                  'band': ['desg', 'desr', 'desi'],
+                  'gain': [1., 1., 1.],
+                  'skynoise': [100., 100., 100.],
+                  'zp': [30., 30., 30.],
+                  'zpsys': ['ab', 'ab', 'ab']})
 
-    # A model with a flat spectrum between 0 and 100 days.
-    model = sncosmo.Model(source=flatsource())
+    # same made up data with aliased column names:
+    obs2 = Table({'MJD': [10., 60., 110.],
+                  'filter': ['desg', 'desr', 'desi'],
+                  'GAIN': [1., 1., 1.],
+                  'skynoise': [100., 100., 100.],
+                  'ZPT': [30., 30., 30.],
+                  'zpmagsys': ['ab', 'ab', 'ab']})
 
-    # parameters to run
-    params = [{'amplitude': 1., 't0': 0., 'z': 0.},
-              {'amplitude': 1., 't0': 100., 'z': 0.},
-              {'amplitude': 1., 't0': 200., 'z': 0.}]
+    for obs in (obs1, obs2):
 
-    # By default, realize_lcs should return all observations for all SNe
-    lcs = sncosmo.realize_lcs(obs, model, params)
-    assert len(lcs[0]) == 3
-    assert len(lcs[1]) == 3
-    assert len(lcs[2]) == 3
+        # A model with a flat spectrum between 0 and 100 days.
+        model = sncosmo.Model(source=flatsource())
 
-    # For trim_obervations=True, only certain observations will be
-    # returned.
-    lcs = sncosmo.realize_lcs(obs, model, params, trim_observations=True)
-    assert len(lcs[0]) == 2
-    assert len(lcs[1]) == 1
-    assert len(lcs[2]) == 0
+        # parameters to run
+        params = [{'amplitude': 1., 't0': 0., 'z': 0.},
+                  {'amplitude': 1., 't0': 100., 'z': 0.},
+                  {'amplitude': 1., 't0': 200., 'z': 0.}]
+
+        # By default, realize_lcs should return all observations for all SNe
+        lcs = sncosmo.realize_lcs(obs, model, params)
+        assert len(lcs[0]) == 3
+        assert len(lcs[1]) == 3
+        assert len(lcs[2]) == 3
+
+        # For trim_obervations=True, only certain observations will be
+        # returned.
+        lcs = sncosmo.realize_lcs(obs, model, params, trim_observations=True)
+        assert len(lcs[0]) == 2
+        assert len(lcs[1]) == 1
+        assert len(lcs[2]) == 0

--- a/sncosmo/tests/test_utils.py
+++ b/sncosmo/tests/test_utils.py
@@ -45,3 +45,9 @@ def test_ppf():
     x = np.linspace(0.05, 0.95, 5.)
     y = utils.ppf(priordist.pdf, x, -np.inf, np.inf)
     assert_allclose(y, priordist.ppf(x), atol=1.e-10)
+
+
+def test_alias_map():
+    mapping = utils.alias_map(['A', 'B_', 'foo'],
+                              {'a': set(['a', 'a_']), 'b': set(['b', 'b_'])})
+    assert mapping == {'a': 'A', 'b': 'B_'}

--- a/sncosmo/utils.py
+++ b/sncosmo/utils.py
@@ -352,6 +352,34 @@ def download_dir(remote_url, dirname):
     buf.close()  # buf not closed when tf is closed.
 
 
+def alias_map(aliased, aliases):
+    """For each key in ``aliases``, find the item in ``aliased`` matching
+    exactly one of the corresponding items in ``aliases``. For example::
+
+        >>> aliases = {'a':set(['a', 'a_']), 'b':set(['b', 'b_'])}
+        >>> alias_map(['A', 'B_', 'foo'], aliases)
+        {'A': 'a', 'B_': 'b'}
+
+    """
+    lowered_to_orig = {key.lower(): key for key in aliased}
+    lowered = set(lowered_to_orig.keys())
+    mapping = {}
+    for key, key_aliases in aliases.items():
+        common = lowered & key_aliases
+        if len(common) == 0:
+            raise ValueError('no alias found for {!r} (possible '
+                             'case-independent aliases: {})'.format(
+                                 key,
+                                 ', '.join(repr(ka) for ka in key_aliases)))
+        if len(common) > 1:
+            raise ValueError('multiple aliases found for {!r}: {}'
+                             .format(key, ', '.join(repr(a) for a in common)))
+
+        mapping[key] = lowered_to_orig[common.pop()]
+
+    return mapping
+
+
 warned = []  # global used in warn_once
 
 


### PR DESCRIPTION
This cleans up our internal handling of photometric data, paving the way for handling data covariance.

Internally, we convert all the supported forms of photometric data (astropy Table, dict of arrays, numpy structured array, various column name aliases) to instances of a new class `PhotometricData` that has fixed attributes, such as `time`, `band`, etc. which are all normal numpy arrays. We then access them like
`data.time`, `data.band` throughout the fitting and plotting code. A couple advantages:

- Having a class allows us to quickly check if some photometric data has already been "standardized" by checking if `isinstance(data, PhotometricData)`.
- We needed a class in order to conveniently pass around off-diagonal covariance on the data (subject of future work).

Note that this class is **not public or documented** and is subject to change. Users should still use astropy `Table`s to pass around photometric data. But it's possible that we'll expose it in the future, perhaps subclassing from `Table`.

This also addresses #70 by reusing the cleaned up "column aliases" code for photometric data in `realize_lcs`.

Finally, there should be some minor speed-ups due to less copying of data structures (untested).