### PR TITLE
WIP: Covariance handling and iterative fit procedure

### DIFF
--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -72,6 +72,7 @@ def chisq(data, model, modelcov=False):
     chisq : float
     """
     data = photometric_data(data)
+    data.sort_by_time()
 
     if data.fluxcov is None and not modelcov:
         mflux = model.bandflux(data.band, data.time,
@@ -385,6 +386,7 @@ def fit_lc(data, model, vparam_names, bounds=None, method='minuit',
 
     # Standardize data
     data = photometric_data(data)
+    data.sort_by_time()
 
     # Make a copy of the model so we can modify it with impunity.
     model = copy.copy(model)
@@ -751,6 +753,7 @@ def nest_lc(data, model, vparam_names, bounds, guess_amplitude_bound=False,
     tied = kwargs.get("tied", None)
 
     data = photometric_data(data)
+    data.sort_by_time()
     model = copy.copy(model)
     bounds = copy.copy(bounds)  # need to copy this b/c we modify it below
 
@@ -998,6 +1001,7 @@ def mcmc_lc(data, model, vparam_names, bounds=None, priors=None,
 
     # Standardize and normalize data.
     data = photometric_data(data)
+    data.sort_by_time()
 
     # Make a copy of the model so we can modify it with impunity.
     model = copy.copy(model)

--- a/sncosmo/photdata.py
+++ b/sncosmo/photdata.py
@@ -87,10 +87,7 @@ class PhotometricData(object):
                     "the data? Use ``sncosmo.select_data(data, mask)`` in "
                     "place of ``data[mask]`` to properly slice covariance.")
 
-        # ensure sorted by time
-        self._sort_by_time()
-
-    def _sort_by_time(self):
+    def sort_by_time(self):
         if not np.all(np.ediff1d(self.time) >= 0.0):
             idx = np.argsort(self.time)
             self.time = self.time[idx]
@@ -115,9 +112,6 @@ class PhotometricData(object):
         newdata.zpsys = self.zpsys[key]
         newdata.fluxcov = (None if self.fluxcov is None else
                            self.fluxcov[np.ix_(key, key)])
-
-        # ensure sorted by time (key could have caused reordering)
-        newdata._sort_by_time()
 
         return newdata
 

--- a/sncosmo/plotting.py
+++ b/sncosmo/plotting.py
@@ -189,7 +189,9 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab',
 
     # Standardize and normalize data.
     if data is not None:
-        data = photometric_data(data).normalized(zp=zp, zpsys=zpsys)
+        data = photometric_data(data)
+        data.sort_by_time()
+        data = data.normalized(zp=zp, zpsys=zpsys)
 
     # Bands to plot
     if data is None:


### PR DESCRIPTION
This PR does three things:

1. Includes data covariance (if present) in all fitting functions' chi squared functions (`fit_lc()`, `nest_lc()`, `mcmc_lc()`).

2. Changes how "model covariance" (e.g. SALT2 model error) is used in `fit_lc()`. Formerly the model covariance was calculated on each call to the chi squared function (it depends on model parameters). However, this is *not* the default treatment in snfit (though it is an option). This PR changes the handling to match the default in snfit, which requires an iterative fit procedure. If `modelcov=True`:

   - First a fit is performed with no model covariance included
   - Model covariance is calculated based on the results of the fit and *fixed*
   - A new fit is performed including the fixed covariance in the chi squared function
   - Repeat previous steps until convergence (parameters change by less than 10% of statistical error bars)

   Because there may be multiple fits performed, the result now includes an `nfit` attribute giving the number of iterations of this process (if `modelcov=True`, `nfit` will be at least 2). The rest of the result attributes are only from the last fit performed.

   I expect this to cause a change in results when using `modelcov=True`, but it should not be large. (and the new behavior is closer to expected).

3. Adds `phase_range` and `wave_range` optional arguments to `fit_lc()`. `phase_range` specifies what data should be used in the fit based on where the data falls relative to the SN phase. Similarly, `wave_range` specifies the valid data based on the bandpass effective rest-frame wavelength.
These also require an iterative fit procedure as outlined above (as phase and rest-frame wavelength depend on model parameters `t0` and `z`. snfit defaults are `phase_range=(-15., 45.)` and `wave_range=(3000., 7000.)`.