### PR TITLE
Bandpass and magnitude system aliases

### DIFF
--- a/docs/_helpers/bandpass_page.py
+++ b/docs/_helpers/bandpass_page.py
@@ -5,12 +5,14 @@ sphinx documentation via the automodule directive."""
 from astropy.extern import six
 from sncosmo.bandpasses import _BANDPASSES
 
+__all__ = []  # so that bandpass_table is not documented.
+
 # string.ascii_letters in py3
 ASCII_LETTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 bandpass_meta = _BANDPASSES.get_loaders_metadata()
-table_delim = "  ".join([11 * '=', 80 * '=', 14 * '=', 8 * '=', 12 * '='])
-table_colnames = ("{0:11}  {1:80}  {2:14}  {3:8}  {4:12}"
+table_delim = "  ".join([15 * '=', 80 * '=', 14 * '=', 8 * '=', 12 * '='])
+table_colnames = ("{0:15}  {1:80}  {2:14}  {3:8}  {4:12}"
                   .format('Name', 'Description', 'Reference', 'Data URL',
                           'Retrieved'))
 urlnums = {}
@@ -49,7 +51,7 @@ def bandpass_table(setname):
         if 'retrieved' in m:
             retrieved = m['retrieved']
 
-        lines.append("{0!r:11}  {1:80}  {2:14}  {3:8}  {4:12}".format(
+        lines.append("{0!r:15}  {1:80}  {2:14}  {3:8}  {4:12}".format(
             m['name'], m['description'], reflink, urllink, retrieved))
 
     lines.append(table_delim)

--- a/docs/_helpers/bandpass_plot.py
+++ b/docs/_helpers/bandpass_plot.py
@@ -1,9 +1,11 @@
 """Helper function to plot a set of bandpasses in sphinx docs."""
 from __future__ import division
 
-import sncosmo
+import numpy as np
 from matplotlib import rc
 from matplotlib import pyplot as plt
+
+import sncosmo
 
 
 def plot_bandpass_set(setname):
@@ -20,8 +22,18 @@ def plot_bandpass_set(setname):
     for m in bandpass_meta:
         if m['filterset'] != setname:
             continue
+        print(m['name'])
         b = sncosmo.get_bandpass(m['name'])
-        ax.plot(b.wave, b.trans, label=m['name'])
+
+        # add zeros on either side of bandpass transmission
+        wave = np.zeros(len(b.wave) + 2)
+        wave[0] = b.wave[0]
+        wave[1:-1] = b.wave
+        wave[-1] = b.wave[-1]
+        trans = np.zeros(len(b.trans) + 2)
+        trans[1:-1] = b.trans
+
+        ax.plot(wave, trans, label=m['name'])
         nbands += 1
 
     ax.set_xlabel("Wavelength ($\\AA$)")

--- a/sncosmo/bandpasses.py
+++ b/sncosmo/bandpasses.py
@@ -318,9 +318,14 @@ class AggregateBandpass(Bandpass):
         Scalar factor to multiply transmissions by. Default is 1.0.
     name : str, optional
         Name of bandpass.
+    family : str, optional
+        Name of "family" this bandpass belongs to. Such an identifier can
+        be useful for identifying bandpasses belonging to the same
+        instrument/filter combination but different focal plane
+        positions.
     """
 
-    def __init__(self, transmissions, prefactor=1.0, name=None):
+    def __init__(self, transmissions, prefactor=1.0, name=None, family=None):
         if len(transmissions) < 1:
             raise ValueError("empty list of transmissions")
 
@@ -335,6 +340,7 @@ class AggregateBandpass(Bandpass):
                               for t in transmissions]
         self.prefactor = prefactor
         self.name = name
+        self.family = family
 
         # Determine min/max wave: since sampled functions are zero outside
         # their domain, minwave is the *largest* minimum x value, and
@@ -428,4 +434,4 @@ class BandpassInterpolator(object):
         name += "at {:f}".format(pos)
 
         return AggregateBandpass(transmissions, prefactor=self.prefactor,
-                                 name=name)
+                                 name=name, family=self.name)

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -129,12 +129,13 @@ snls3_landolt_meta = {
     'reference': ('B14a',
                   '`Betoule et al. (2014) <http://adsabs.harvard.edu'
                   '/abs/2014A%26A...568A..22B>`__, Footnote 21')}
-for name, fname in [('standard::u', 'bandpasses/snls3-landolt/sux-shifted.dat'),
-                    ('standard::b', 'bandpasses/snls3-landolt/sb-shifted.dat'),
-                    ('standard::v', 'bandpasses/snls3-landolt/sv-shifted.dat'),
-                    ('standard::r', 'bandpasses/snls3-landolt/sr-shifted.dat'),
-                    ('standard::i', 'bandpasses/snls3-landolt/si-shifted.dat')]:
-        _BANDPASSES.register_loader(name, load_bandpass_remote_aa,
+for name, fname in [
+        ('standard::u', 'bandpasses/snls3-landolt/sux-shifted.dat'),
+        ('standard::b', 'bandpasses/snls3-landolt/sb-shifted.dat'),
+        ('standard::v', 'bandpasses/snls3-landolt/sv-shifted.dat'),
+        ('standard::r', 'bandpasses/snls3-landolt/sr-shifted.dat'),
+        ('standard::i', 'bandpasses/snls3-landolt/si-shifted.dat')]:
+    _BANDPASSES.register_loader(name, load_bandpass_remote_aa,
                                 args=(fname,), meta=snls3_landolt_meta)
 
 des_meta = {
@@ -183,7 +184,9 @@ for name, fname in [('f435w', 'bandpasses/acs-wfc/wfc_F435W.dat'),
                     ('f606w', 'bandpasses/acs-wfc/wfc_F606W.dat'),
                     ('f625w', 'bandpasses/acs-wfc/wfc_F625W.dat'),
                     ('f775w', 'bandpasses/acs-wfc/wfc_F775W.dat'),
-                    ('f814w', 'bandpasses/acs-wfc/wfc_F814W.dat'),
+                    # TODO: 814 filter from STScI has multiple identical
+                    # wavelength values.
+                    #('f814w', 'bandpasses/acs-wfc/wfc_F814W.dat'),
                     ('f850lp', 'bandpasses/acs-wfc/wfc_F850LP.dat')]:
     _BANDPASSES.register_loader(name, load_bandpass_remote_aa,
                                 args=(fname,), meta=acs_meta)
@@ -251,7 +254,7 @@ for name, fname in [('f218w', "bandpasses/wfc3-uvis/f218w.UVIS2.tab"),
                     ('uvf775w', "bandpasses/wfc3-uvis/f775w.UVIS2.tab"),
                     ('uvf814w', "bandpasses/wfc3-uvis/f814w.UVIS2.tab"),
                     ('uvf850lp', "bandpasses/wfc3-uvis/f850lp.UVIS2.tab")]:
-    _BANDPASSES.register_loader(name, load_bandpass_remote_aa,
+    _BANDPASSES.register_loader(name, load_bandpass_remote_wfc3,
                                 args=(fname,), meta=wfc3uvis_meta)
 
 
@@ -335,27 +338,32 @@ for name, fname in [('f070w', 'bandpasses/nircam/jwst_nircam_f070w.dat'),
                                 args=(fname,), meta=jwst_nircam_meta)
 
 
-jwst_miri_meta = {'filterset': 'jwst-miri',
-                  'dataurl': 'http://www.stsci.edu/jwst/instruments/miri/'
-                             'instrumentdesign/filters',
-                  'retrieved': '09 Sep 2014',
-                  'description': 'James Webb Space Telescope MIRI '
-                                 'filters (idealized tophats)'}
-for name, ctr, width in [('f560w', 5.6, 1.2),
-                         ('f770w', 7.7, 2.2),
-                         ('f1000w', 10., 2.),
-                         ('f1130w', 11.3, 0.7),
-                         ('f1280w', 12.8, 2.4),
-                         ('f1500w', 15., 3.),
-                         ('f1800w', 18., 3.),
-                         ('f2100w', 21., 5.),
-                         ('f2550w', 25.5, 4.),
-                         ('f1065c', 10.65, 0.53),
+jwst_miri_meta = {
+    'filterset': 'jwst-miri',
+    'dataurl': ('http://ircamera.as.arizona.edu/MIRI/'
+                'ImPCE_TN-00072-ATC-Iss2.xlsx'),
+    'retrieved': '16 Feb 2017',
+    'description': 'James Webb Space Telescope MIRI filters'}
+for name in ['f560w', 'f770w', 'f1000w', 'f1130w', 'f1280w',
+             'f1500w', 'f1800w', 'f2100w', 'f2550w']:
+    fname = "bandpasses/miri/jwst_miri_{}.dat".format(name)
+    _BANDPASSES.register_loader(name, load_bandpass_remote_um,
+                                args=(fname,), meta=jwst_miri_meta)
+
+
+jwst_miri_meta2 = {'filterset': 'jwst-miri-tophat',
+                   'dataurl': ('http://www.stsci.edu/jwst/instruments/miri/'
+                               'instrumentdesign/filters'),
+                   'retrieved': '09 Sep 2014',
+                   'description': ('James Webb Space Telescope MIRI '
+                                   'filters (idealized tophat)')}
+for name, ctr, width in [('f1065c', 10.65, 0.53),
                          ('f1140c', 11.4, 0.57),
                          ('f1550c', 15.5, 0.78),
                          ('f2300c', 23., 4.6)]:
     _BANDPASSES.register_loader(name, tophat_bandpass_um,
-                                args=(ctr, width), meta=jwst_miri_meta)
+                                args=(ctr, width), meta=jwst_miri_meta2)
+
 
 # LSST bandpasses
 lsst_meta = {'filterset': 'lsst',
@@ -370,10 +378,11 @@ for letter in ['u', 'g', 'r', 'i', 'z', 'y']:
                                 args=(relpath,), meta=lsst_meta)
 
 # Keplercam
-keplercam_meta = {'filterset': 'keplercam',
-                  'dataurl': 'http://supernovae.in2p3.fr/sdss_snls_jla/ReadMe.html',
-                  'retrieved': '13 Feb 2017',
-                  'description': 'Keplercam transmissions as used in JLA'}
+keplercam_meta = {
+    'filterset': 'keplercam',
+    'dataurl': 'http://supernovae.in2p3.fr/sdss_snls_jla/ReadMe.html',
+    'retrieved': '13 Feb 2017',
+    'description': 'Keplercam transmissions as used in JLA'}
 for name, fname in [('keplercam::us', 'bandpasses/keplercam/Us_Keplercam.txt'),
                     ('keplercam::b', 'bandpasses/keplercam/B_Keplercam.txt'),
                     ('keplercam::v', 'bandpasses/keplercam/V_Keplercam.txt'),

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -186,7 +186,7 @@ for name, fname in [('f435w', 'bandpasses/acs-wfc/wfc_F435W.dat'),
                     ('f775w', 'bandpasses/acs-wfc/wfc_F775W.dat'),
                     # TODO: 814 filter from STScI has multiple identical
                     # wavelength values.
-                    #('f814w', 'bandpasses/acs-wfc/wfc_F814W.dat'),
+                    # ('f814w', 'bandpasses/acs-wfc/wfc_F814W.dat'),
                     ('f850lp', 'bandpasses/acs-wfc/wfc_F850LP.dat')]:
     _BANDPASSES.register_loader(name, load_bandpass_remote_aa,
                                 args=(fname,), meta=acs_meta)
@@ -400,8 +400,8 @@ fourshooter_meta = {
 for name, fname in [('4shooter2::us', 'bandpasses/4shooter2/Us_4Shooter2.txt'),
                     ('4shooter2::b', 'bandpasses/4shooter2/B_4Shooter2.txt'),
                     ('4shooter2::v', 'bandpasses/4shooter2/V_4Shooter2.txt'),
-                    ('4shooter2::r', 'bandpasses/4shooter2/r_4Shooter2.txt'),
-                    ('4shooter2::i', 'bandpasses/4shooter2/i_4Shooter2.txt')]:
+                    ('4shooter2::r', 'bandpasses/4shooter2/R_4Shooter2.txt'),
+                    ('4shooter2::i', 'bandpasses/4shooter2/I_4Shooter2.txt')]:
         _BANDPASSES.register_loader(name, load_bandpass_remote_aa,
                                     args=(fname,), meta=fourshooter_meta)
 # =============================================================================
@@ -830,3 +830,4 @@ _MAGSYSTEMS.register_loader(
           'description': 'Betoule et al (2012) calibration of SDSS system.'})
 
 _MAGSYSTEMS.alias('ab_b12', 'ab-b12')
+_MAGSYSTEMS.alias('vegahst', 'vega')

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -120,6 +120,22 @@ for name, fname in [('bessellux', 'bessell/bessell_ux.dat'),
                                 args=('data/bandpasses/' + fname,),
                                 meta=bessell_meta)
 
+# Shifted bessell filters used in SNLS3 (in units of photon / photon)
+snls3_landolt_meta = {
+    'filterset': 'snls3-landolt',
+    'dataurl': 'http://supernovae.in2p3.fr/sdss_snls_jla/ReadMe.html',
+    'retrieved': '13 February 2017',
+    'description': 'Bessell bandpasses shifted as in JLA analysis',
+    'reference': ('B14a',
+                  '`Betoule et al. (2014) <http://adsabs.harvard.edu'
+                  '/abs/2014A%26A...568A..22B>`__, Footnote 21')}
+for name, fname in [('standard::u', 'bandpasses/snls3-landolt/sux-shifted.dat'),
+                    ('standard::b', 'bandpasses/snls3-landolt/sb-shifted.dat'),
+                    ('standard::v', 'bandpasses/snls3-landolt/sv-shifted.dat'),
+                    ('standard::r', 'bandpasses/snls3-landolt/sr-shifted.dat'),
+                    ('standard::i', 'bandpasses/snls3-landolt/si-shifted.dat')]:
+        _BANDPASSES.register_loader(name, load_bandpass_remote_aa,
+                                args=(fname,), meta=snls3_landolt_meta)
 
 des_meta = {
     'filterset': 'des',
@@ -172,6 +188,10 @@ for name, fname in [('f435w', 'bandpasses/acs-wfc/wfc_F435W.dat'),
     _BANDPASSES.register_loader(name, load_bandpass_remote_aa,
                                 args=(fname,), meta=acs_meta)
 
+_BANDPASSES.alias('acswf::f606w', 'f606w')
+_BANDPASSES.alias('acswf::f775w', 'f775w')
+_BANDPASSES.alias('acswf::f850lp', 'f850lp')
+
 
 # HST NICMOS NIC2 bandpasses: remote
 nicmos_meta = {'filterset': 'nicmos-nic2',
@@ -183,6 +203,9 @@ for name, fname in [
         ('nicf160w', 'bandpasses/nicmos-nic2/hst_nicmos_nic2_f160w.dat')]:
     _BANDPASSES.register_loader(name, load_bandpass_remote_aa,
                                 args=(fname,), meta=nicmos_meta)
+
+_BANDPASSES.alias('nicmos2::f110w', 'nicf110w')
+_BANDPASSES.alias('nicmos2::f160w', 'nicf160w')
 
 
 # WFC3 IR bandpasses: remote
@@ -269,6 +292,18 @@ for name, fname in [
     _BANDPASSES.register_loader(name, load_bandpass_remote_aa,
                                 args=(fname,), meta=csp_meta)
 
+_BANDPASSES.alias('swope2::u', 'cspu')
+_BANDPASSES.alias('swope2::b', 'cspb')
+_BANDPASSES.alias('swope2::g', 'cspg')
+_BANDPASSES.alias('swope2::v', 'cspv3014')
+_BANDPASSES.alias('swope2::v1', 'cspv3009')
+_BANDPASSES.alias('swope2::v2', 'cspv9844')
+_BANDPASSES.alias('swope2::r', 'cspr')
+_BANDPASSES.alias('swope2::i', 'cspi')
+_BANDPASSES.alias('swope2::y', 'cspys')
+_BANDPASSES.alias('swope2::j', 'cspjs')
+_BANDPASSES.alias('swope2::h', 'csphs')
+
 
 jwst_nircam_meta = {'filterset': 'jwst-nircam',
                     'dataurl': 'http://www.stsci.edu/jwst/instruments/nircam'
@@ -322,7 +357,7 @@ for name, ctr, width in [('f560w', 5.6, 1.2),
     _BANDPASSES.register_loader(name, tophat_bandpass_um,
                                 args=(ctr, width), meta=jwst_miri_meta)
 
-
+# LSST bandpasses
 lsst_meta = {'filterset': 'lsst',
              'dataurl': ('https://github.com/lsst/throughputs/tree/'
                          '7632edaa9e93d06576e34a065ea4622de8cc48d0/baseline'),
@@ -333,6 +368,19 @@ for letter in ['u', 'g', 'r', 'i', 'z', 'y']:
     relpath = 'bandpasses/lsst/total_{}.dat'.format(letter)
     _BANDPASSES.register_loader(name, load_bandpass_remote_nm,
                                 args=(relpath,), meta=lsst_meta)
+
+# Keplercam
+keplercam_meta = {'filterset': 'keplercam',
+                  'dataurl': 'http://supernovae.in2p3.fr/sdss_snls_jla/ReadMe.html',
+                  'retrieved': '13 Feb 2017',
+                  'description': 'Keplercam transmissions as used in JLA'}
+for name, fname in [('keplercam::us', 'bandpasses/keplercam/Us_Keplercam.txt'),
+                    ('keplercam::b', 'bandpasses/keplercam/B_Keplercam.txt'),
+                    ('keplercam::v', 'bandpasses/keplercam/V_Keplercam.txt'),
+                    ('keplercam::r', 'bandpasses/keplercam/r_Keplercam.txt'),
+                    ('keplercam::i', 'bandpasses/keplercam/i_Keplercam.txt')]:
+        _BANDPASSES.register_loader(name, load_bandpass_remote_aa,
+                                    args=(fname,), meta=keplercam_meta)
 
 
 # =============================================================================
@@ -502,8 +550,8 @@ _SOURCES.register_loader('hsiao-subsampled',
 website = 'http://supernovae.in2p3.fr/salt/doku.php?id=salt_templates'
 g10ref = ('G10', 'Guy et al. 2010 '
           '<http://adsabs.harvard.edu/abs/2010A%26A...523A...7G>')
-b14ref = ('B14', 'Betoule et al. 2014 '
-          '<http://arxiv.org/abs/1401.4064>')
+b14ref = ('B14b', 'Betoule et al. 2014 '
+          '<http://adsabs.harvard.edu/abs/2014A%26A...568A..22B>')
 for topdir, ver, ref in [('salt2-2-0', '2.0', g10ref),
                          ('salt2-4', '2.4', b14ref)]:
     meta = {'type': 'SN Ia', 'subclass': '`~sncosmo.SALT2Source`',

--- a/sncosmo/io.py
+++ b/sncosmo/io.py
@@ -272,7 +272,7 @@ def _expand_bands(band_list, meta):
     else:
         # For other bandpasses, get_bandpass will return the same object
         # on each call, so just use it directly.
-        return [sncosmo.get_bandpass(name) for name in band_list]
+        return [get_bandpass(name) for name in band_list]
 
 
 def _read_salt2(name_or_obj, read_covmat=False, expand_bands=False):

--- a/sncosmo/magsystems.py
+++ b/sncosmo/magsystems.py
@@ -9,7 +9,7 @@ import astropy.constants as const
 
 from ._registry import Registry
 from .bandpasses import get_bandpass
-from .utils import integration_grid
+from .utils import integration_grid, warn_once
 from .constants import H_ERG_S, SPECTRUM_BANDFLUX_SPACING
 
 __all__ = ['get_magsystem', 'MagSystem', 'SpectralMagSystem',
@@ -87,57 +87,99 @@ class CompositeMagSystem(MagSystem):
 
     Parameters
     ----------
-    bands: iterable of `~sncosmo.Bandpass` or str
-        The filters in the magnitude system.
-    standards: iterable of `~sncosmo.MagSystem` or str,
-        The spectrophotmetric flux standards for each band, in the
-        same order as `bands`.
-    offsets: list_like
-        The magnitude of standard in the given band. A positive offset
-        means that the composite magsystem zeropoint flux is brighter
-        than the standard.
+    bands: dict, optional
+        Dictionary where keys are `~sncosmo.Bandpass` instances or names,
+        thereof and values are 2-tuples of magnitude system and offset.
+        The offset gives the magnitude of standard in the given band.
+        A positive offset means that the composite magsystem zeropoint flux
+        is higher (brighter) than that of the standard.
+    families : dict, optional
+        Similar to the ``bands`` argument, but keys are strings that apply to
+        any bandpass that has a matching ``family`` attribute. This is useful
+        for generated bandpasses where the transmission differs across
+        focal plane (and hence the bandpass at each position is unique), but
+        all photometry has been calibrated to the same offset.
+    name : str
+        The ``name`` attribute of the magnitude system.
+
+    Examples
+    --------
+    Create a magnitude system defined in only two SDSS bands where an
+    object with AB magnitude of 0 would have a magnitude of 0.01 and 0.02
+    in the two bands respectively:
+
+    >>> sncosmo.CompositeMagSystem(bands={'sdssg': ('ab', 0.01),
+    ...                                   'sdssr': ('ab', 0.02)})
     """
 
-    def __init__(self, bands, standards, offsets, name=None):
+    def __init__(self, bands=None, standards=None, offsets=None,
+                 families=None, name=None):
         super(CompositeMagSystem, self).__init__(name=name)
 
-        if not len(bands) == len(offsets) == len(standards):
-            raise ValueError('Lengths of bands, standards, and offsets '
-                             'must match.')
+        # detect use of deprecated API
+        using_deprecated = (bands is not None and
+                            (standards is not None or
+                             offsets is not None))
 
-        self._bands = [get_bandpass(band) for band in bands]
-        self._standards = [get_magsystem(s) for s in standards]
-        self._offsets = offsets
+        # old API
+        if using_deprecated:
+            warn_once("`standards`, `offsets` keyword in CompositeMagSystem",
+                      '1.5', '2.0',
+                      "Use new constructor API (see documentation).")
+
+            if not len(bands) == len(offsets) == len(standards):
+                raise ValueError('Lengths of bands, standards, and offsets '
+                                 'must match.')
+
+            self._bands = {
+                get_bandpass(band): (get_magsystem(magsys), offset)
+                for band, magsys, offset in zip(bands, standards, offsets)}
+
+        # new API includes "families"
+        else:
+            if bands is not None:
+                self._bands = {
+                    get_bandpass(band): (get_magsystem(magsys), offset)
+                    for band, (magsys, offset) in bands.items()}
+            else:
+                self._bands = {}
+
+            if families is not None:
+                self._families = {f: (get_magsystem(magsys), offset)
+                                  for f, (magsys, offset) in families.items()}
+            else:
+                self._families = {}
 
     @property
     def bands(self):
         return self._bands
 
-    @property
-    def standards(self):
-        return self._standards
-
-    @property
-    def offsets(self):
-        return self._offsets
-
     def _refspectrum_bandflux(self, band):
-        if band not in self._bands:
-            raise ValueError('band not in local magnitude system')
-        i = self._bands.index(band)
-        standard = self._standards[i]
-        offset = self._offsets[i]
+        val = self._bands.get(band)
 
-        return 10.**(0.4 * offset) * standard.zpbandflux(band)
+        if val is not None:
+            standard, offset = val
+            return 10.**(0.4 * offset) * standard.zpbandflux(band)
+
+        if hasattr(band, 'family'):
+            val = self._families.get(band.family)
+            if val is not None:
+                standard, offset = val
+                return 10.**(0.4 * offset) * standard.zpbandflux(band)
+
+        raise ValueError('band not defined in composite magnitude system')
 
     def __str__(self):
         s = "CompositeMagSystem {!r}:\n".format(self.name)
 
-        for i in range(len(self._bands)):
+        for band, (magsys, offset) in self._bands.items():
             s += "  {!r}: system={!r}  offset={}\n".format(
-                self._bands[i].name,
-                self._standards[i].name,
-                self._offsets[i])
+                band, magsys, offset)
+
+        for family, (magsys, offset) in self._families.items():
+            s += "  {!r}: system={!r}  offset={}\n".format(
+                family, magsys, offset)
+
         return s
 
 

--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -1203,9 +1203,6 @@ class Model(_ModelBase):
         z : float or list_like, optional
             If given, evaluate the overlap when the model is at the given
             redshifts. If `None`, use the model redshift.
-        checkeffects : bool
-            If True, include wavelength limits of added effects (e.g. dust)
-            when defining the range of wavelengths accessible to the model.
 
         Returns
         -------
@@ -1223,8 +1220,8 @@ class Model(_ModelBase):
         shift = (1. + z)/(1+self._parameters[0])
         for i, b in enumerate(band):
             b = get_bandpass(b)
-            overlap[i, :] = ((b.wave[0] > self.minwave()*shift) &
-                             (b.wave[-1] < self.maxwave()*shift))
+            overlap[i, :] = ((b.minwave() > self.minwave() * shift) &
+                             (b.maxwave() < self.maxwave() * shift))
         if ndim == (0, 0):
             return overlap[0, 0]
         if ndim[1] == 0:

--- a/sncosmo/tests/test_builtins.py
+++ b/sncosmo/tests/test_builtins.py
@@ -11,6 +11,7 @@ def test_hst_bands():
         sncosmo.get_bandpass(bandname)
 
 
+@remote_data
 def test_jwst_miri_bands():
     for bandname in ['f1130w']:
         sncosmo.get_bandpass(bandname)

--- a/sncosmo/utils.py
+++ b/sncosmo/utils.py
@@ -544,5 +544,5 @@ def warn_once(name, depver, rmver, extra=None):
                "and will be removed in sncosmo {}".format(name, depver, rmver))
         if extra is not None:
             msg += " " + extra
-        warnings.warn(msg)
+        warnings.warn(msg, stacklevel=2)
         warned.append(name)


### PR DESCRIPTION
This PR has a few minor fixes and cleanups but mainly adds support for many bandpasses and magnitude systems defined in snfit (SALT2 software) for the JLA light curve analysis. For example,
with this PR, `sncosmo.get_bandpass('acswf::f606w')` works, as does the string `ACSWF::F606W` when found in light curve files.

One open question is: should these aliases be registered by default, or should one have to do something special to register them, such as: `sncosmo.register_aliases('snfit')` (or `'jla'` or similar)?