### PR TITLE
Setting and getting model parameters

### DIFF
--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -195,8 +195,7 @@ class _ModelBase(object):
     """Base class for anything with parameters.
 
     Derived classes must have properties ``_param_names`` (list of str)
-    and ``_parameters`` (1-d numpy.ndarray). In the future this might
-    use model classes in astropy.modeling as a base class.
+    and ``_parameters`` (1-d numpy.ndarray).
     """
 
     @property
@@ -218,15 +217,27 @@ class _ModelBase(object):
 
     def set(self, **param_dict):
         """Set parameters of the model by name."""
-        for key, val in param_dict.items():
-            try:
-                i = self._param_names.index(key)
-            except ValueError:
-                raise KeyError("Unknown parameter: " + repr(key))
-            self._parameters[i] = val
+        self.update(param_dict)
+
+    def update(self, param_dict):
+        """Set parameters of the model from a dictionary."""
+        for key, value in param_dict.items():
+            self[key] = value
+
+    def __setitem__(self, key, value):
+        """Set a single parameter of the model by name."""
+        try:
+            i = self._param_names.index(key)
+        except ValueError:
+            raise KeyError("Unknown parameter: " + repr(key))
+        self._parameters[i] = value
 
     def get(self, name):
         """Get parameter of the model by name."""
+        return self[name]
+
+    def __getitem__(self, name):
+        """Get parameter of the model by name"""
         try:
             i = self._param_names.index(name)
         except ValueError:

--- a/sncosmo/tests/test_models.py
+++ b/sncosmo/tests/test_models.py
@@ -199,6 +199,16 @@ class TestModel:
         assert 'hostebv' in self.model.param_names
         assert len(self.model.parameters) == nparams + 1
 
+    def test_set_and_get(self):
+        """Test different methods for setting and getting parameters."""
+
+        a = self.model.get('amplitude')
+        self.model['amplitude'] = 2 * a   # test __setitem__
+        assert self.model['amplitude'] == 2 * a   # test __getitem__
+
+        self.model.update({'amplitude': 4 * a})  # test update
+        assert self.model['amplitude'] == 4 * a
+
 
 def test_effect_frame_free():
     """Test Model with PropagationEffect with a 'free' frame."""


### PR DESCRIPTION
Adds following methods for setting and getting model parameters:
```
model[name] = value
value = model[name]
model.update({name1: value1, name2: value2})
```
Closes #185.