### PR TITLE
Fixes for #205

### DIFF
--- a/sncosmo/__init__.py
+++ b/sncosmo/__init__.py
@@ -101,7 +101,7 @@ def test(package=None, test_path=None, args=None, plugins=None,
 
 # Create default configurations. The file sncosmo.cfg should be
 # kept in sync with the ConfigItems here.
-class Conf(ConfigNamespace):
+class _Conf(ConfigNamespace):
     """Configuration parameters for sncosmo."""
     data_dir = ConfigItem(
         None,
@@ -115,9 +115,11 @@ class Conf(ConfigNamespace):
         "'SFD_dust_4096_ngp.fits' and 'SFD_dust_4096_sgp.fits'. "
         "Example: sfd98_dir = /home/user/data/sfd98",
         cfgtype='string(default=None)')
+    remote_timeout = ConfigItem(
+        10.0, "Remote timeout in seconds.")
 
 # Create an instance of the class we just defined.
-conf = Conf()
+conf = _Conf()
 
 # Update the user's ~/.astropy/config/sncosmo.cfg if needed.
 update_default_config("sncosmo",  # pkg

--- a/sncosmo/utils.py
+++ b/sncosmo/utils.py
@@ -222,10 +222,10 @@ def _download_file(remote_url, target):
     from astropy.extern.six.moves.urllib.request import urlopen, Request
     from astropy.extern.six.moves.urllib.error import URLError, HTTPError
     from astropy.utils.console import ProgressBarOrSpinner
-    from astropy.utils.data import conf
+    from . import conf
 
     timeout = conf.remote_timeout
-
+    download_block_size = 32768
     try:
         # Pretend to be a web browser (IE 6.0). Some servers that we download
         # from forbid access from programs.
@@ -247,12 +247,12 @@ def _download_file(remote_url, target):
             dlmsg = "Downloading {0}".format(remote_url)
             with ProgressBarOrSpinner(size, dlmsg) as p:
                 bytes_read = 0
-                block = remote.read(conf.download_block_size)
+                block = remote.read(download_block_size)
                 while block:
                     target.write(block)
                     bytes_read += len(block)
                     p.update(bytes_read)
-                    block = remote.read(conf.download_block_size)
+                    block = remote.read(download_block_size)
 
     # Append a more informative error message to HTTPErrors, URLErrors.
     except HTTPError as e:
@@ -296,7 +296,7 @@ def download_file(remote_url, local_name):
         Whenever there's a problem getting the remote file.
     """
 
-    from astropy.extern.six.moves.urllib.error import HTTPError
+    from astropy.extern.six.moves.urllib.error import HTTPError, URLError
 
     # ensure target directory exists
     dn = os.path.dirname(local_name)
@@ -320,8 +320,8 @@ def download_file(remote_url, local_name):
         try:
             with open(local_name, 'wb') as target:
                 _download_file(remote_url, target)
-        except HTTPError:
-            # in case of error downloading, remove opened file.
+        except:
+            # in case of error downloading, remove file.
             if os.path.exists(local_name):
                 os.remove(local_name)
             raise


### PR DESCRIPTION
Fixes for #205 :

- It was awkward to use `astropy.utils.data.conf.remote_timeout` to set the remote timeout time, since we're not using the download features from there. Instead, now use `sncosmo.conf.remote_timeout`.
- Default timeout increased from 3 to 10 seconds.
- Delete (very likely empty) file whenever *any* error occurs in `_download_file`, not just an `HTTPError`.