### PR TITLE
Include cython source in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include CITATION.md
 include LICENSE.rst
 include setup.cfg
 
-recursive-include sncosmo *.c
+recursive-include sncosmo *.c *.pyx
 recursive-include docs *
 
 exclude __pycache__


### PR DESCRIPTION
This would make building sncosmo on Python 3.7 possible in conda-forge (see https://github.com/conda-forge/sncosmo-feedstock/pull/6#issuecomment-451778463).