### PR TITLE
Small change to copy function in model class to fix free propagation effect fitting issue (#235)

### DIFF
--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -1647,7 +1647,7 @@ class Model(_ModelBase):
                     effects=self._effects,
                     effect_names=self._effect_names,
                     effect_frames=self._effect_frames)
-        new._parameters[0:2] = self._parameters[0:2]
+        new._parameters[0:] = self._parameters[0:]
         return new
 
     def __deepcopy__(self, memo):


### PR DESCRIPTION
Just changed __copy__ to copy over all parameters, not just the first 2 as discussed in issue 235. 