### PR TITLE
WIP : Adding partial solution to #240

### DIFF
--- a/sncosmo/__init__.py
+++ b/sncosmo/__init__.py
@@ -8,7 +8,7 @@ import os
 from astropy.config import ConfigItem, ConfigNamespace
 from astropy.config.configuration import update_default_config
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 
 def test(package=None, test_path=None, args=None, plugins=None,

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -787,7 +787,7 @@ for name, sntype, fn in p18Models_CC:
 meta = {'type': 'SN Ia',
         'subclass': '`~sncosmo.SALT2Source`', 'ref': ref}
 _SOURCES.register_loader('salt2-extended', load_salt2model,
-                         args=('models/pierel/salt2',), version='2.0',
+                         args=('models/pierel/salt2-extended',), version='2.0',
                          meta=meta)
 # =============================================================================
 # MagSystems


### PR DESCRIPTION
This is towards a solution for the issue #240 reported by @tallamjr.  We changed the definition of `salt2-extended` version 2 in `builtins.py` to download the correct file. However, I still find 
```
 model = sncosmo.Model(source='salt2-extended')
Downloading http://sncosmo.github.io/data/models/pierel/salt2-extended.tar.gz
|========================================================================| 4.9M/4.9M (100.00%)         0s
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/rbiswas/.local/lib/python3.7/site-packages/sncosmo-2.0.1-py3.7-macosx-10.7-x86_64.egg/sncosmo/models.py", line 1054, in __init__
    self._source = get_source(source, copy=True)
  File "/Users/rbiswas/.local/lib/python3.7/site-packages/sncosmo-2.0.1-py3.7-macosx-10.7-x86_64.egg/sncosmo/models.py", line 88, in get_source
    return cp(_SOURCES.retrieve(name, version=version))
  File "/Users/rbiswas/.local/lib/python3.7/site-packages/sncosmo-2.0.1-py3.7-macosx-10.7-x86_64.egg/sncosmo/_registry.py", line 177, in retrieve
    version=latest_version)
  File "/Users/rbiswas/.local/lib/python3.7/site-packages/sncosmo-2.0.1-py3.7-macosx-10.7-x86_64.egg/sncosmo/builtins.py", line 447, in load_salt2model
    abspath = DATADIR.abspath(relpath, isdir=True)
  File "/Users/rbiswas/.local/lib/python3.7/site-packages/sncosmo-2.0.1-py3.7-macosx-10.7-x86_64.egg/sncosmo/utils.py", line 464, in abspath
    raise RuntimeError("Tarfile not unpacked into expected "
RuntimeError: Tarfile not unpacked into expected subdirectory. Please file an issue.
```

	modified:   sncosmo/__init__.py
	modified:   sncosmo/builtins.py

