### PR TITLE
fixed salt2_extended version 2 download location

### DIFF
--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -787,7 +787,7 @@ for name, sntype, fn in p18Models_CC:
 meta = {'type': 'SN Ia',
         'subclass': '`~sncosmo.SALT2Source`', 'ref': ref}
 _SOURCES.register_loader('salt2-extended', load_salt2model,
-                         args=('models/pierel/salt2',), version='2.0',
+                         args=('models/pierel/salt2-extended',), version='2.0',
                          meta=meta)
 # =============================================================================
 # MagSystems


### PR DESCRIPTION
builtins.py thought the salt2-extended directory was at pierel/salt2, it should be pierel/salt2-extended.