### PR TITLE
Fix argument mutation in `fit_lc` and `mcmc_lc`

### DIFF
--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -439,8 +439,7 @@ def fit_lc(data, model, vparam_names, bounds=None, method='minuit',
     vparam_names = [s for s in model.param_names if s in vparam_names]
 
     # initialize bounds
-    if bounds is None:
-        bounds = {}
+    bounds = copy.deepcopy(bounds) if bounds else {}
 
     # Check that 'z' is bounded (if it is going to be fit).
     if 'z' in vparam_names:
@@ -1067,8 +1066,7 @@ def mcmc_lc(data, model, vparam_names, bounds=None, priors=None,
     # Make a copy of the model so we can modify it with impunity.
     model = copy.copy(model)
 
-    if bounds is None:
-        bounds = {}
+    bounds = copy.deepcopy(bounds) if bounds else {}
     if priors is None:
         priors = {}
 

--- a/sncosmo/tests/test_fit_func_mutation.py
+++ b/sncosmo/tests/test_fit_func_mutation.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3.7
+# -*- coding: UTF-8 -*-
+
+"""Tests for the ``fit_funcs`` module."""
+
+from copy import deepcopy
+from unittest import TestCase
+
+import sncosmo
+
+
+class BaseTestingClass(TestCase):
+    """Tests for an arbitrary sncosmo model"""
+
+    def _test_mutation(self):
+        """Test a pipeline fitting function does not mutate arguments"""
+
+        # Use sncosmo example data for testing
+        data = sncosmo.load_example_data()
+        model = sncosmo.Model('salt2')
+        params = model.param_names
+        bounds = {'z': (0.3, 0.7)}
+
+        # Preserve original input data
+        original_data = deepcopy(data)
+        original_model = deepcopy(model)
+        original_bounds = deepcopy(bounds)
+        original_params = deepcopy(params)
+
+        # Check for argument mutation
+        self.fit_func(data, model, vparam_names=model.param_names,
+                      bounds=bounds)
+
+        self.assertTrue(
+            all(original_data == data),
+            '``data`` argument was mutated')
+
+        self.assertSequenceEqual(
+            original_params, params,
+            '``vparam_names`` argument was mutated')
+
+        self.assertEqual(
+            original_bounds, bounds,
+            '``bounds`` argument was mutated')
+
+        self.assertSequenceEqual(
+            original_model.parameters.tolist(),
+            model.parameters.tolist(),
+            '``model`` argument was mutated')
+
+
+class SimpleFit(BaseTestingClass):
+    """Tests for the ``simple_fit`` function"""
+
+    @staticmethod
+    def fit_func(*a, **kw):
+        return sncosmo.fit_lc(*a, **kw)
+
+    def test_mutation(self):
+        """Test arguments are not mutated"""
+
+        self._test_mutation()
+
+
+class NestFit(BaseTestingClass):
+    """Tests for the ``nest_fit`` function"""
+
+    @staticmethod
+    def fit_func(*a, **kw):
+        return sncosmo.nest_lc(*a, **kw)
+
+    def test_mutation(self):
+        """Test arguments are not mutated"""
+
+        self._test_mutation()
+
+
+class MCMCFit(BaseTestingClass):
+    """Tests for the ``mcmc_fit`` function"""
+
+    @staticmethod
+    def fit_func(*a, **kw):
+        return sncosmo.mcmc_lc(*a, **kw)
+
+    def test_mutation(self):
+        """Test arguments are not mutated"""
+
+        self._test_mutation()

--- a/sncosmo/tests/test_fit_func_mutation.py
+++ b/sncosmo/tests/test_fit_func_mutation.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3.7
 # -*- coding: UTF-8 -*-
 
+<<<<<<< Updated upstream
 """Tests for the ``fit_funcs`` module."""
+=======
+"""Tests for argument mutation by fitting functions."""
+>>>>>>> Stashed changes
 
 from copy import deepcopy
 from unittest import TestCase


### PR DESCRIPTION
I ran into a bug where the fitting functions would modify the `bounds` argument before copying it. For example:

```python
import sncosmo

model = sncosmo.Model('salt2')
data = sncosmo.load_example_data()
bounds = {'z':(0.3, 0.7)}
result, fitted_model = sncosmo.fit_lc(
    data, model,
    ['z', 't0', 'x0', 'x1', 'c'],
    bounds=bounds) 

print(bounds)
> {'z': (0.3, 0.7), 't0': (54995.0, 55180.0)}
```

This PR makes minor changes in `fit_lc` and `mcmc_lc` where instead of using

```python
if bounds is None:
    bounds={}
```

the bounds are copied as

```python
bounds = copy.deepcopy(bounds) if bounds else {}
```

It also adds a few tests to validate the above change.
