### PR TITLE
Fix argument mutation when fitting

### DIFF
--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -439,8 +439,7 @@ def fit_lc(data, model, vparam_names, bounds=None, method='minuit',
     vparam_names = [s for s in model.param_names if s in vparam_names]
 
     # initialize bounds
-    if bounds is None:
-        bounds = {}
+    bounds = copy.deepcopy(bounds) if bounds else {}
 
     # Check that 'z' is bounded (if it is going to be fit).
     if 'z' in vparam_names:
@@ -1067,8 +1066,7 @@ def mcmc_lc(data, model, vparam_names, bounds=None, priors=None,
     # Make a copy of the model so we can modify it with impunity.
     model = copy.copy(model)
 
-    if bounds is None:
-        bounds = {}
+    bounds = copy.deepcopy(bounds) if bounds else {}
     if priors is None:
         priors = {}
 

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -52,6 +52,49 @@ class TestFitting:
         self.data = data
         self.params = params
 
+    def _test_mutation(self, fit_func):
+        """Test a pipeline fitting function does not mutate arguments"""
+
+        # Use sncosmo example data for testing
+        data = sncosmo.load_example_data()
+        model = sncosmo.Model('salt2')
+        params = model.param_names
+        bounds = {'z': (0.3, 0.7)}
+
+        # Preserve original input data
+        original_data = deepcopy(data)
+        original_model = deepcopy(model)
+        original_bounds = deepcopy(bounds)
+        original_params = deepcopy(params)
+
+        # Check for argument mutation
+        fit_func(data, model, vparam_names=model.param_names, bounds=bounds)
+        self.assertTrue(
+            all(original_data == data),
+            '``data`` argument was mutated')
+
+        self.assertSequenceEqual(
+            original_params, params,
+            '``vparam_names`` argument was mutated')
+
+        self.assertEqual(
+            original_bounds, bounds,
+            '``bounds`` argument was mutated')
+
+        self.assertSequenceEqual(
+            original_model.parameters.tolist(),
+            model.parameters.tolist(),
+            '``model`` argument was mutated')
+
+    def test_fitlc_arg_mutation(self):
+        self._test_mutation(sncosmo.fit_lc)
+
+    def test_nestlc_arg_mutation(self):
+        self._test_mutation(sncosmo.nest_lc)
+
+    def test_mcmclc_arg_mutation(self):
+        self._test_mutation(sncosmo.mcmc_lc)
+
     @pytest.mark.skipif('not HAS_IMINUIT')
     def test_fit_lc(self):
         """Ensure that fit results match input model parameters (data are

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -72,18 +72,19 @@ class TestFitting:
 
         # Some fitting functions require bounds for all varied parameters
         bounds = {}
-        for param, param_val in zip(self.params, self.model.parameters):
-            bounds[param] = (param_val * .9, param_val * 1.1)
+        for param, param_val in self.params.items():
+            bounds[param] = (param_val * .95, param_val * 1.05)
 
         # Preserve original input data
+        vparams = list(self.params.keys())
         test_data = deepcopy(self.data)
         test_model = deepcopy(self.model)
         test_bounds = deepcopy(bounds)
-        test_params = deepcopy(self.params)
+        test_vparams = deepcopy(vparams)
 
         # Check for argument mutation
-        fit_func(test_data, test_model, test_params, bounds=test_bounds)
-        param_preserved = all(a == b for a, b in zip(self.params, test_params))
+        fit_func(test_data, test_model, test_vparams, bounds=test_bounds)
+        param_preserved = all(a == b for a, b in zip(vparams, test_vparams))
         model_preserved = all(
             a == b for a, b in
             zip(self.model.parameters, test_model.parameters)

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -1,12 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSES
 
+from copy import deepcopy
 from os.path import dirname, join
 
-import pytest
 import numpy as np
-from numpy.random import RandomState
-from numpy.testing import assert_allclose, assert_almost_equal
+import pytest
 from astropy.table import Table
+from numpy.random import RandomState
+from numpy.testing import assert_allclose
 
 import sncosmo
 

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -13,6 +13,7 @@ import sncosmo
 
 try:
     import iminuit
+
     HAS_IMINUIT = True
 
 except ImportError:
@@ -20,6 +21,7 @@ except ImportError:
 
 try:
     import nestle
+
     HAS_NESTLE = True
 
 except ImportError:
@@ -27,6 +29,7 @@ except ImportError:
 
 try:
     import emcee
+
     HAS_EMCEE = True
 
 except ImportError:
@@ -48,12 +51,14 @@ class TestFitting:
         model.set(**params)
         flux = model.bandflux(bands, times, zp=zp, zpsys=zpsys)
         fluxerr = len(bands) * [0.1 * np.max(flux)]
-        data = Table({'time': times,
-                      'band': bands,
-                      'flux': flux,
-                      'fluxerr': fluxerr,
-                      'zp': zp,
-                      'zpsys': zpsys})
+        data = Table({
+            'time': times,
+            'band': bands,
+            'flux': flux,
+            'fluxerr': fluxerr,
+            'zp': zp,
+            'zpsys': zpsys
+        })
 
         # reset parameters
         model.set(z=0., t0=0., amplitude=1.)
@@ -78,30 +83,33 @@ class TestFitting:
 
         # Check for argument mutation
         fit_func(test_data, test_model, test_params, bounds=test_bounds)
-        vparams_mutated = all(a == b for a, b in zip(self.params, test_params))
-        model_mutated = all(a == b for a, b in
-                            zip(self.model.parameters, test_model.parameters))
+        param_preserved = all(a == b for a, b in zip(self.params, test_params))
+        model_preserved = all(
+            a == b for a, b in
+            zip(self.model.parameters, test_model.parameters)
+        )
 
         err_msg = '``{}`` argument was mutated'
         assert all(self.data == test_data), err_msg.format('data')
         assert bounds == test_bounds, err_msg.format('bounds')
-        assert vparams_mutated, err_msg.format('vparam_names')
-        assert model_mutated, err_msg.format('model')
+        assert param_preserved, err_msg.format('vparam_names')
+        assert model_preserved, err_msg.format('model')
 
+    @pytest.mark.skipif('not HAS_IMINUIT')
     def test_fitlc_arg_mutation(self):
-        """Test ``fit_lc`` does not mutate it's arguemts"""
+        """Test ``fit_lc`` does not mutate it's arguments"""
 
         self._test_mutation(sncosmo.fit_lc)
 
     @pytest.mark.skipif('not HAS_NESTLE')
     def test_nestlc_arg_mutation(self):
-        """Test ``nest_lc`` does not mutate it's arguemts"""
+        """Test ``nest_lc`` does not mutate it's arguments"""
 
         self._test_mutation(sncosmo.nest_lc)
 
     @pytest.mark.skipif('not HAS_EMCEE')
     def test_mcmclc_arg_mutation(self):
-        """Test ``mcmc_lc`` does not mutate it's arguemts"""
+        """Test ``mcmc_lc`` does not mutate it's arguments"""
 
         self._test_mutation(sncosmo.mcmc_lc)
 

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -67,7 +67,7 @@ class TestFitting:
 
         # Some fitting functions require bounds for all varied parameters
         bounds = {}
-        for param, param_val in zip(params, model.parameters):
+        for param, param_val in zip(self.params, self.model.parameters):
             bounds[param] = (param_val * .9, param_val * 1.1)
 
         # Preserve original input data

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -69,22 +69,10 @@ class TestFitting:
 
         # Check for argument mutation
         fit_func(data, model, vparam_names=model.param_names, bounds=bounds)
-        self.assertTrue(
-            all(original_data == data),
-            '``data`` argument was mutated')
-
-        self.assertSequenceEqual(
-            original_params, params,
-            '``vparam_names`` argument was mutated')
-
-        self.assertEqual(
-            original_bounds, bounds,
-            '``bounds`` argument was mutated')
-
-        self.assertSequenceEqual(
-            original_model.parameters.tolist(),
-            model.parameters.tolist(),
-            '``model`` argument was mutated')
+        assert all(original_data == data), '``data`` argument was mutated'
+        assert original_bounds == bounds, '``bounds`` argument was mutated'
+        assert all(a == b for a, b in zip(original_params, params)), '``vparam_names`` argument was mutated'
+        assert all(a == b for a, b in zip(original_model.parameters, model.parameters.tolist())), '``model`` argument was mutated'
 
     def test_fitlc_arg_mutation(self):
         self._test_mutation(sncosmo.fit_lc)

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -77,9 +77,11 @@ class TestFitting:
     def test_fitlc_arg_mutation(self):
         self._test_mutation(sncosmo.fit_lc)
 
+    @pytest.mark.skipif('not HAS_NESTLE')
     def test_nestlc_arg_mutation(self):
         self._test_mutation(sncosmo.nest_lc)
 
+    @pytest.mark.skipif('not HAS_IMINUIT')
     def test_mcmclc_arg_mutation(self):
         self._test_mutation(sncosmo.mcmc_lc)
 

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -79,7 +79,8 @@ class TestFitting:
         # Check for argument mutation
         fit_func(test_data, test_model, test_params, bounds=test_bounds)
         vparams_mutated = all(a == b for a, b in zip(self.params, test_params))
-        model_mutated = all(a == b for a, b in zip(self.model.parameters, test_model.parameters))
+        model_mutated = all(a == b for a, b in
+                            zip(self.model.parameters, test_model.parameters))
 
         err_msg = '``{}`` argument was mutated'
         assert all(self.data == test_data), err_msg.format('data')


### PR DESCRIPTION
This PR makes minor changes in `fit_lc` and `mcmc_lc` where instead of using

```python
if bounds is None:
    bounds={}
```

the bounds are copied as

```python
bounds = copy.deepcopy(bounds) if bounds else {}
```

It also adds a few tests to validate the above change.
