### PR TITLE
PEP8 import optimizer

### DIFF
--- a/sncosmo/bandpasses.py
+++ b/sncosmo/bandpasses.py
@@ -2,15 +2,15 @@
 
 import copy
 
-import numpy as np
-from scipy.interpolate import splrep, splev
-from astropy.utils import lazyproperty
-from astropy.io import ascii
 import astropy.units as u
+import numpy as np
+from astropy.io import ascii
+from astropy.utils import lazyproperty
+from scipy.interpolate import splev, splrep
 
 from ._registry import Registry
-from .utils import integration_grid
 from .constants import HC_ERG_AA, SPECTRUM_BANDFLUX_SPACING
+from .utils import integration_grid
 
 __all__ = ['get_bandpass', 'read_bandpass', 'Bandpass', 'AggregateBandpass',
            'BandpassInterpolator']

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -19,10 +19,16 @@ from astropy.utils.data import get_pkg_data_filename
 from . import conf
 from . import io
 from . import snfitio
-from .bandpasses import (Bandpass, _BANDPASSES, _BANDPASS_INTERPOLATORS, read_bandpass)
+from .bandpasses import (
+    Bandpass, _BANDPASSES, _BANDPASS_INTERPOLATORS, read_bandpass)
+
 from .constants import BANDPASS_TRIM_LEVEL
-from .magsystems import (ABMagSystem, CompositeMagSystem, SpectralMagSystem, _MAGSYSTEMS)
-from .models import (MLCS2k2Source, SALT2Source, SNEMOSource, TimeSeriesSource, _SOURCES)
+from .magsystems import (
+    ABMagSystem, CompositeMagSystem, SpectralMagSystem, _MAGSYSTEMS)
+
+from .models import (
+    MLCS2k2Source, SALT2Source, SNEMOSource, TimeSeriesSource, _SOURCES)
+
 from .spectrum import Spectrum
 from .utils import DataMirror
 

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -6,32 +6,25 @@
 - MagSystems
 """
 
-import string
-import tarfile
-import warnings
 import os
+import warnings
 from os.path import join
-import codecs
-from collections import OrderedDict
 
 import numpy as np
-from astropy import wcs, units as u
-from astropy.io import ascii, fits
-from astropy.config import ConfigItem, get_cache_dir
+from astropy import units as u, wcs
+from astropy.config import get_cache_dir
+from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
 
+from . import conf
 from . import io
 from . import snfitio
-from .utils import download_file, download_dir, DataMirror
-from .models import (Source, TimeSeriesSource, SALT2Source, MLCS2k2Source,
-                     SNEMOSource, _SOURCES)
-from .bandpasses import (Bandpass, read_bandpass, _BANDPASSES,
-                         _BANDPASS_INTERPOLATORS)
-from .spectrum import Spectrum
-from .magsystems import (MagSystem, SpectralMagSystem, ABMagSystem,
-                         CompositeMagSystem, _MAGSYSTEMS)
-from . import conf
+from .bandpasses import (Bandpass, _BANDPASSES, _BANDPASS_INTERPOLATORS, read_bandpass)
 from .constants import BANDPASS_TRIM_LEVEL
+from .magsystems import (ABMagSystem, CompositeMagSystem, SpectralMagSystem, _MAGSYSTEMS)
+from .models import (MLCS2k2Source, SALT2Source, SNEMOSource, TimeSeriesSource, _SOURCES)
+from .spectrum import Spectrum
+from .utils import DataMirror
 
 # This module is only imported for its side effects.
 __all__ = []

--- a/sncosmo/constants.py
+++ b/sncosmo/constants.py
@@ -1,9 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Constants used elsewhere in sncosmo."""
 
-import astropy.units as u
 import astropy.constants as const
-
+import astropy.units as u
 
 BANDPASS_TRIM_LEVEL = 0.001
 SPECTRUM_BANDFLUX_SPACING = 1.0

--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -1,17 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import copy
-import time
 import math
-from collections import OrderedDict
+import time
 import warnings
+from collections import OrderedDict
 
 import numpy as np
-from scipy.interpolate import InterpolatedUnivariateSpline as Spline1d
 
-from .photdata import photometric_data, select_data
-from .utils import Result, Interp1D, ppf
-from .bandpasses import get_bandpass
+from .photdata import photometric_data
+from .utils import Interp1D, Result, ppf
 
 __all__ = ['fit_lc', 'nest_lc', 'mcmc_lc', 'flatten_result', 'chisq']
 

--- a/sncosmo/io.py
+++ b/sncosmo/io.py
@@ -1,20 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Functions for supernova light curve I/O"""
 
+import json
 import math
 import os
-import sys
-import re
-import json
 from collections import OrderedDict
 
 import numpy as np
-from astropy.table import Table
-from astropy.io import fits
 from astropy import wcs
+from astropy.io import fits
+from astropy.table import Table
 
-from .utils import dict_to_array
 from .bandpasses import get_bandpass
+from .utils import dict_to_array
 
 __all__ = ['read_lc', 'write_lc', 'load_example_data', 'read_griddata_ascii',
            'read_griddata_fits', 'write_griddata_ascii', 'write_griddata_fits']

--- a/sncosmo/magsystems.py
+++ b/sncosmo/magsystems.py
@@ -4,13 +4,11 @@ import abc
 import math
 
 import numpy as np
-import astropy.units as u
-import astropy.constants as const
 
 from ._registry import Registry
 from .bandpasses import get_bandpass
-from .utils import integration_grid
 from .constants import H_ERG_S, SPECTRUM_BANDFLUX_SPACING
+from .utils import integration_grid
 
 __all__ = ['get_magsystem', 'MagSystem', 'SpectralMagSystem',
            'ABMagSystem', 'CompositeMagSystem']

--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -4,27 +4,29 @@
 
 import abc
 import os
-from collections import OrderedDict as odict
 from copy import copy as cp
-from textwrap import dedent
 from math import ceil
-import itertools
+from textwrap import dedent
 
-import numpy as np
-from scipy.interpolate import (InterpolatedUnivariateSpline as Spline1d,
-                               RectBivariateSpline as Spline2d)
-from astropy.utils.misc import isiterable
-from astropy import (cosmology, units as u, constants as const)
 import extinction
+import numpy as np
+from astropy import (cosmology, units as u)
+from astropy.utils.misc import isiterable
+from scipy.interpolate import (
+    InterpolatedUnivariateSpline as Spline1d,
+    RectBivariateSpline as Spline2d
+)
 
-from .io import (read_griddata_ascii, read_griddata_fits,
-                 read_multivector_griddata_ascii)
 from ._registry import Registry
-from .bandpasses import get_bandpass, Bandpass
+from .bandpasses import Bandpass, get_bandpass
+from .constants import HC_ERG_AA, MODEL_BANDFLUX_SPACING
+from .io import (
+    read_griddata_ascii, read_griddata_fits,
+    read_multivector_griddata_ascii
+)
 from .magsystems import get_magsystem
 from .salt2utils import BicubicInterpolator, SALT2ColorLaw
 from .utils import integration_grid
-from .constants import HC_ERG_AA, MODEL_BANDFLUX_SPACING
 
 __all__ = ['get_source', 'Source', 'TimeSeriesSource', 'StretchSource',
            'SALT2Source', 'MLCS2k2Source', 'SNEMOSource', 'Model',

--- a/sncosmo/photdata.py
+++ b/sncosmo/photdata.py
@@ -1,16 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Convenience functions for photometric data."""
 
-from collections import OrderedDict
 import copy
-import math
+from collections import OrderedDict
 
 import numpy as np
 from astropy.table import Table
 
-from .utils import alias_map
 from .bandpasses import get_bandpass
 from .magsystems import get_magsystem
+from .utils import alias_map
 
 __all__ = ['select_data']
 

--- a/sncosmo/plotting.py
+++ b/sncosmo/plotting.py
@@ -1,13 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Functions to plot light curve data and models."""
 
-import math
-
 import numpy as np
 
-from .models import Model
 from .bandpasses import get_bandpass
 from .magsystems import get_magsystem
+from .models import Model
 from .photdata import photometric_data
 from .utils import format_value
 
@@ -170,7 +168,7 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab',
 
     from matplotlib import pyplot as plt
     from matplotlib import cm
-    from matplotlib.ticker import MaxNLocator, NullFormatter
+    from matplotlib.ticker import MaxNLocator
     from mpl_toolkits.axes_grid1 import make_axes_locatable
 
     if data is None and model is None:

--- a/sncosmo/registry.py
+++ b/sncosmo/registry.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Public interface functions for registering and retrieving from registries"""
 
-from . import models
 from . import bandpasses
 from . import magsystems
+from . import models
 
 __all__ = ['register_loader', 'register']
 

--- a/sncosmo/salt2utils.pyx
+++ b/sncosmo/salt2utils.pyx
@@ -13,16 +13,6 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.math cimport fabs
 from libc.string cimport memcpy
 
-cimport
-numpy as np
-import numpy as np
-from cpython.mem import PyMem_Free, PyMem_Malloc
-from libc.math cimport
-
-fabs
-from libc.string cimport
-
-memcpy
 
 cdef int find_index_binary(double *values, int n, double x):
     """Find index i in array such that values[i] <= x < values[i+1].

--- a/sncosmo/salt2utils.pyx
+++ b/sncosmo/salt2utils.pyx
@@ -13,6 +13,16 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.math cimport fabs
 from libc.string cimport memcpy
 
+cimport
+numpy as np
+import numpy as np
+from cpython.mem import PyMem_Free, PyMem_Malloc
+from libc.math cimport
+
+fabs
+from libc.string cimport
+
+memcpy
 
 cdef int find_index_binary(double *values, int n, double x):
     """Find index i in array such that values[i] <= x < values[i+1].

--- a/sncosmo/simulation.py
+++ b/sncosmo/simulation.py
@@ -1,15 +1,13 @@
 """Tools for simulation of transients."""
 
-import sys
-import math
 import copy
 from collections import OrderedDict
 
 import numpy as np
+from astropy.cosmology import FlatLambdaCDM
+from astropy.table import Table
 from numpy import random
 from scipy.interpolate import InterpolatedUnivariateSpline as Spline1d
-from astropy.table import Table
-from astropy.cosmology import FlatLambdaCDM
 
 from .utils import alias_map
 

--- a/sncosmo/snanaio.py
+++ b/sncosmo/snanaio.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict as odict
 
 import numpy as np
-
 from astropy.io import fits
 from astropy.table import Table, vstack
 

--- a/sncosmo/snfitio.py
+++ b/sncosmo/snfitio.py
@@ -5,12 +5,13 @@ Functions for reading formats specific to snfit (SALT2) software.
 (except lightcurves, which are in io.py).
 """
 
-from collections import OrderedDict
 import os
+from collections import OrderedDict
 
 import numpy as np
+
+from .bandpasses import BandpassInterpolator
 from .io import _read_salt2
-from .bandpasses import Bandpass, BandpassInterpolator
 
 
 def _collect_scalars(values):

--- a/sncosmo/spectrum.py
+++ b/sncosmo/spectrum.py
@@ -1,13 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import numpy as np
 import astropy.units as u
-import astropy.constants as const
-from scipy.interpolate import splrep, splev
+import numpy as np
+from scipy.interpolate import splev, splrep
 
 from .bandpasses import get_bandpass
+from .constants import HC_ERG_AA, SPECTRUM_BANDFLUX_SPACING
 from .utils import integration_grid
-from .constants import SPECTRUM_BANDFLUX_SPACING, HC_ERG_AA
 
 __all__ = ['Spectrum']
 

--- a/sncosmo/tests/test_bandpasses.py
+++ b/sncosmo/tests/test_bandpasses.py
@@ -2,8 +2,8 @@
 import os
 
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 import sncosmo
 from sncosmo import Bandpass

--- a/sncosmo/tests/test_builtins.py
+++ b/sncosmo/tests/test_builtins.py
@@ -1,6 +1,6 @@
-import sncosmo
-
 import pytest
+
+import sncosmo
 
 
 @pytest.mark.might_download

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -2,11 +2,11 @@
 
 from os.path import dirname, join
 
-import pytest
 import numpy as np
-from numpy.random import RandomState
-from numpy.testing import assert_allclose, assert_almost_equal
+import pytest
 from astropy.table import Table
+from numpy.random import RandomState
+from numpy.testing import assert_allclose
 
 import sncosmo
 

--- a/sncosmo/tests/test_io.py
+++ b/sncosmo/tests/test_io.py
@@ -1,15 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSES
 
-from io import StringIO, BytesIO
 import os
+from io import BytesIO, StringIO
 from os.path import dirname, join
-from tempfile import mkdtemp, NamedTemporaryFile
+from tempfile import NamedTemporaryFile, mkdtemp
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_almost_equal
-from astropy.table import Table
 from astropy import wcs
 from astropy.io import fits
+from astropy.table import Table
+from numpy.testing import assert_allclose
+
 import sncosmo
 
 # Dummy data used for read_lc/write_lc round-tripping tests

--- a/sncosmo/tests/test_magsystems.py
+++ b/sncosmo/tests/test_magsystems.py
@@ -3,10 +3,9 @@
 import math
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_almost_equal
-from astropy import units as u
-from astropy.utils.data import get_pkg_data_filename
 import pytest
+from astropy import units as u
+from numpy.testing import assert_allclose, assert_almost_equal
 
 import sncosmo
 

--- a/sncosmo/tests/test_models.py
+++ b/sncosmo/tests/test_models.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSES
 
 from io import StringIO
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_approx_equal
 

--- a/sncosmo/tests/test_plotting.py
+++ b/sncosmo/tests/test_plotting.py
@@ -2,7 +2,9 @@
 
 import numpy as np
 import pytest
+
 import sncosmo
+
 try:
     from matplotlib.figure import Figure
     HAS_MATPLOTLIB = True

--- a/sncosmo/tests/test_registry.py
+++ b/sncosmo/tests/test_registry.py
@@ -2,6 +2,7 @@
 """Test registry functions."""
 
 import numpy as np
+
 import sncosmo
 
 

--- a/sncosmo/tests/test_salt2source.py
+++ b/sncosmo/tests/test_salt2source.py
@@ -5,8 +5,8 @@
 import os
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_approx_equal
 import pytest
+from numpy.testing import assert_allclose
 
 import sncosmo
 

--- a/sncosmo/tests/test_salt2utils.py
+++ b/sncosmo/tests/test_salt2utils.py
@@ -8,7 +8,6 @@ from scipy.interpolate import RectBivariateSpline
 import sncosmo
 from sncosmo.salt2utils import BicubicInterpolator, SALT2ColorLaw
 
-
 # On Python 2 highest protocol is 2.
 # Protocols 0 and 1 don't work on the classes here!
 TEST_PICKLE_PROTOCOLS = (2, 3, 4)

--- a/sncosmo/tests/test_simulation.py
+++ b/sncosmo/tests/test_simulation.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSES
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_almost_equal
 from astropy.table import Table
 
 import sncosmo

--- a/sncosmo/tests/test_snanaio.py
+++ b/sncosmo/tests/test_snanaio.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSES
 
-from os.path import join, dirname
+from os.path import dirname, join
 
 from numpy.testing import assert_allclose
 

--- a/sncosmo/tests/test_utils.py
+++ b/sncosmo/tests/test_utils.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSES
 
-from tempfile import mkdtemp
 import os
+from tempfile import mkdtemp
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_approx_equal
-from scipy.stats import norm
 import pytest
+from numpy.testing import assert_allclose
+from scipy.stats import norm
 
 from sncosmo import utils
 

--- a/sncosmo/utils.py
+++ b/sncosmo/utils.py
@@ -1,10 +1,9 @@
-from collections import OrderedDict
-import os
-import sys
-import math
-import warnings
-import socket
 import codecs
+import math
+import os
+import socket
+import warnings
+from collections import OrderedDict
 
 import numpy as np
 from scipy import integrate, optimize
@@ -289,8 +288,6 @@ def download_file(remote_url, local_name):
     URLError
         Whenever there's a problem getting the remote file.
     """
-
-    from urllib.error import HTTPError, URLError
 
     # ensure target directory exists
     dn = os.path.dirname(local_name)


### PR DESCRIPTION
I noticed a few unused import statements. This is potentially problematic because it clutters up the name space and adds overhead when importing `sncosmo`. The latter of these is especially important when running on systems like NERSC where imports are already painfully slow. I took the liberty of running an automatic PEP8 import optimizer.

NERSC is down for maintenance while they prepare for the Perlmutter machine, but I get a small ~1.6 % improvement in runtime when importing `sncosmo` on my local machine. The improvement is tiny, but it's essentially free.
Before optimization: 0.682 ms
After optimization: 0.671 ms