### PR TITLE
Don't segfault if a minuit fit fails.

### DIFF
--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -37,6 +37,12 @@ def generate_chisq(data, model, signature='iminuit', modelcov=False):
     # parameters)
     if signature == 'iminuit':
         def chisq(*parameters):
+            # When a fit fails, iminuit sometimes calls the chisq function with the
+            # parameters set to nan. This sometimes leads to a segfault in sncosmo
+            # because the internal functions (specifically BicubicInterpolator) aren't
+            # designed to handle that. See https://github.com/sncosmo/sncosmo/issues/266
+            # for details. For now, return nan to minuit if it tries to set any
+            # parameter to nan.
             if np.any(np.isnan(parameters)):
                 return np.nan
             model.parameters = parameters

--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -37,6 +37,8 @@ def generate_chisq(data, model, signature='iminuit', modelcov=False):
     # parameters)
     if signature == 'iminuit':
         def chisq(*parameters):
+            if np.any(np.isnan(parameters)):
+                return np.nan
             model.parameters = parameters
             model_flux = model.bandflux(data.band, data.time,
                                         zp=data.zp, zpsys=data.zpsys)


### PR DESCRIPTION
Fixes the segfault discussed in #266 

Note that this doesn't magically prevent fits from failing, it just prevents sncosmo from segfaulting, and minuit raises an exception instead.