### PR TITLE
Robustify bicubic interpolation

### DIFF
--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -50,15 +50,6 @@ def generate_chisq(data, model, spectra, signature='iminuit', modelcov=False):
     # parameters)
     if signature == 'iminuit':
         def chisq(*parameters):
-            # When a fit fails, iminuit sometimes calls the chisq function with
-            # the parameters set to nan. This sometimes leads to a segfault in
-            # sncosmo because the internal functions (specifically
-            # BicubicInterpolator) aren't designed to handle that. See
-            # https://github.com/sncosmo/sncosmo/issues/266 for details. For
-            # now, return nan to minuit if it tries to set any parameter to
-            # nan.
-            if np.any(np.isnan(parameters)):
-                return np.nan
             model.parameters = parameters
 
             full_chisq = 0.

--- a/sncosmo/salt2utils.pyx
+++ b/sncosmo/salt2utils.pyx
@@ -215,6 +215,9 @@ cdef class BicubicInterpolator(object):
             y_j = yc[j]
 
             # if y is out of range, we won't be using the value at all
+            # the inverted comparison here also catches y_j=nan, which
+            # would otherwise cause find_index_unsafe() to return -1
+            # below, leading to a segfault.
             if (not (y_j >= self.ymin and y_j <= self.ymax)):
                 yflagvec[j] = -1
             else:
@@ -243,6 +246,8 @@ cdef class BicubicInterpolator(object):
             x_i = xc[i]
 
             # precompute some stuff for x
+            # again, the inverted comparison shields find_index_unsafe()
+            # from invalid input
             if (not (x_i >= self.xmin and x_i <= self.xmax)):
                 xflag = -1
             else:

--- a/sncosmo/salt2utils.pyx
+++ b/sncosmo/salt2utils.pyx
@@ -215,7 +215,7 @@ cdef class BicubicInterpolator(object):
             y_j = yc[j]
 
             # if y is out of range, we won't be using the value at all
-            if (y_j < self.ymin or y_j > self.ymax):
+            if (not (y_j >= self.ymin and y_j <= self.ymax)):
                 yflagvec[j] = -1
             else:
                 iy = find_index_unsafe(self.yval, self.ny, y_j, iy)
@@ -243,7 +243,7 @@ cdef class BicubicInterpolator(object):
             x_i = xc[i]
 
             # precompute some stuff for x
-            if (x_i < self.xmin or x_i > self.xmax):
+            if (not (x_i >= self.xmin and x_i <= self.xmax)):
                 xflag = -1
             else:
                 ix = find_index_unsafe(self.xval, self.nx, x_i, ix)


### PR DESCRIPTION
Fixes #266. Also adds a work-around for a feature introduced in iminuit 1.5.2 that leads to heap corruption on some platforms.
