### PR TITLE
Iminuit deprecation of "forced_parameters"

### DIFF
--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -668,8 +668,8 @@ def fit_lc(data=None, model=None, vparam_names=[], bounds=None, spectra=None,
         ndof -= len(vparam_names)
 
         # Minuit keywords changed in v1.4.3. Handle that gracefully.
-        from packaging import version
-        if version.parse(iminuit.__version__) >= version.parse("1.4.3"):
+        from distutils.version import LooseVersion
+        if LooseVersion(iminuit.__version__) >= LooseVersion("1.4.3"):
             param_names_kwargs = {'name': model.param_names}
         else:
             param_names_kwargs = {'forced_parameters': model.param_names}

--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -668,7 +668,7 @@ def fit_lc(data=None, model=None, vparam_names=[], bounds=None, spectra=None,
         ndof -= len(vparam_names)
 
         m = iminuit.Minuit(fitchisq, errordef=1.,
-                           forced_parameters=model.param_names,
+                           name=model.param_names,
                            print_level=(1 if verbose >= 2 else 0),
                            throw_nan=True, **kwargs)
         d, l = m.migrad(ncall=maxcall)
@@ -725,7 +725,7 @@ def fit_lc(data=None, model=None, vparam_names=[], bounds=None, spectra=None,
                                       signature='iminuit', modelcov=modelcov)
 
             m = iminuit.Minuit(fitchisq, errordef=1.,
-                               forced_parameters=model.param_names,
+                               name=model.param_names,
                                print_level=(1 if verbose >= 2 else 0),
                                throw_nan=True, **kwargs)
             d, l = m.migrad(ncall=maxcall)

--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -667,10 +667,16 @@ def fit_lc(data=None, model=None, vparam_names=[], bounds=None, spectra=None,
                 ndof += len(spectrum)
         ndof -= len(vparam_names)
 
+        # Minuit keywords changed in v1.4.3. Handle that gracefully.
+        from packaging import version
+        if version.parse(iminuit.__version__) >= version.parse("1.4.3"):
+            param_names_kwargs = {'name': model.param_names}
+        else:
+            param_names_kwargs = {'forced_parameters': model.param_names}
+
         m = iminuit.Minuit(fitchisq, errordef=1.,
-                           name=model.param_names,
                            print_level=(1 if verbose >= 2 else 0),
-                           throw_nan=True, **kwargs)
+                           throw_nan=True, **param_names_kwargs, **kwargs)
         d, l = m.migrad(ncall=maxcall)
         if verbose:
             print("{} function calls; {} dof.".format(d.nfcn, ndof))
@@ -725,9 +731,8 @@ def fit_lc(data=None, model=None, vparam_names=[], bounds=None, spectra=None,
                                       signature='iminuit', modelcov=modelcov)
 
             m = iminuit.Minuit(fitchisq, errordef=1.,
-                               name=model.param_names,
                                print_level=(1 if verbose >= 2 else 0),
-                               throw_nan=True, **kwargs)
+                               throw_nan=True, **param_names_kwargs, **kwargs)
             d, l = m.migrad(ncall=maxcall)
 
             if verbose:


### PR DESCRIPTION
In newer versions of iminuit, the "forced_parameters" keyword has been deprecated and replaced by "name". Right now, running sncosmo with a new version of iminuit spits out deprecation warnings for every fit.

It looks like this change happened in iminuit v1.4.3 (from June 24, 2020). We can approach this either by dropping compatibility with v1.4.2 or earlier, or by including a workaround in the code to use the right keyword depending on the iminuit version. This PR implements the workaround. There seem to have been quite a few changes to the iminuit API recently... I'm not sure if we are affected by any other ones.