### PR TITLE
Fixes to tox tests.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,8 @@ requires = [
     "numpy==1.17.3; python_version>='3.8'",
 ]
 build-backend = 'setuptools.build_meta'
+
+[tool.pytest.ini_options]
+markers = [
+    "might_download: marks tests that might download a file",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3
-envlist = py36
+envlist = py3
 isolated_build = true
 
 [testenv]
@@ -8,4 +8,8 @@ passenv = HOME
 changedir = {envtmpdir}
 deps = pytest
        pytest-astropy
+       iminuit
+       nestle
+       emcee
+       matplotlib
 commands = python -c "import sncosmo; sncosmo.test()"


### PR DESCRIPTION
This PR fixes a few issues with the current tests.

Currently tox doesn't run a bunch of tests because optional dependencies aren't installed (iminuit, emcee, nestle and matplotlib). I added those dependencies.

I also added a marker for "might_download". This marker is used in a lot of the tests, but wasn't previously labeled which spit out warnings.

Finally, I changed tox to run on whatever version of python 3 is available instead of forcing it to find python3.6 which I assume that most people no longer have on their machines.