### PR TITLE
Fix flatten_result problem with deprecated cov_names keyword (#285)

### DIFF
--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -161,13 +161,13 @@ def flatten_result(res):
     for n1 in res.param_names:
         for n2 in res.param_names:
             key = n1 + '_' + n2 + '_cov'
-            if n1 not in res.cov_names or n2 not in res.cov_names:
+            if n1 not in res.vparam_names or n2 not in res.vparam_names:
                 flat[key] = 0.
             elif res.covariance is None:
                 flat[key] = float('nan')
             else:
-                i = res.cov_names.index(n1)
-                j = res.cov_names.index(n2)
+                i = res.vparam_names.index(n1)
+                j = res.vparam_names.index(n2)
                 flat[key] = res.covariance[i, j]
 
     return flat

--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -162,6 +162,19 @@ class TestFitting:
 
         assert_allclose(fitmodel.parameters, self.model.parameters, rtol=0.05)
 
+    @pytest.mark.skipif('not HAS_IMINUIT')
+    def test_flatten_result(self):
+        """Ensure that the flatten_result function works correctly."""
+        res, fitmodel = sncosmo.fit_lc(self.data, self.model,
+                                       ['amplitude', 'z', 't0'],
+                                       bounds={'z': (0., 1.0)})
+
+        flat_result = sncosmo.flatten_result(res)
+
+        # Make sure that we got a dictionary of results back.
+        assert isinstance(flat_result, dict)
+        assert len(flat_result) > 0
+
 
 @pytest.mark.might_download
 @pytest.mark.skipif('not HAS_IMINUIT')


### PR DESCRIPTION
Fixes #285