### PR TITLE
fixed bugs in the implementation of the SALT3 error model

### DIFF
--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -1129,6 +1129,8 @@ class SALT3Source(SALT2Source):
         m0 = self._model['M0'](phase, wave)
         m1 = self._model['M1'](phase, wave)
         tmp = trans * wave
+
+        # evaluate avg M0 + x1*M1 across a bandpass
         f0 = np.sum(m0 * tmp, axis=1)/tmp.sum()
         m1int = np.sum(m1 * tmp, axis=1)/tmp.sum()
         ftot = f0 + x1 * m1int
@@ -1139,6 +1141,8 @@ class SALT3Source(SALT2Source):
         lcrv11 = self._model['LCRV11'](phase, band.wave_eff)[:, 0]
         lcrv01 = self._model['LCRV01'](phase, band.wave_eff)[:, 0]
 
+        # variance in M0 + x1*M1 at the effective wavelength
+        # of a bandpass
         v = (lcrv00 + 2.0 * x1 * lcrv01 + x1 * x1 * lcrv11)
 
         # v is supposed to be variance but can go negative
@@ -1149,7 +1153,7 @@ class SALT3Source(SALT2Source):
 
         # avoid warnings due to evaluating 0. / 0. in f0 / ftot
         with np.errstate(invalid='ignore'):
-            # new SALT3 error prescription
+            # turn M0+x1*M1 error into a relative error
             result = v/ftot**2.
 
         # treat cases where ftot is negative the same as snfit

--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -1100,6 +1100,7 @@ class SALT3Source(SALT2Source):
         # model covariance is interpolated to 1st order
         for key in ['LCRV00', 'LCRV11', 'LCRV01']:
             phase, wave, values = read_griddata_ascii(names_or_objs[key])
+            values *= self._SCALE_FACTOR**2.
             self._model[key] = BicubicInterpolator(phase, wave, values)
 
         # Set the colorlaw based on the "color correction" file.
@@ -1128,8 +1129,8 @@ class SALT3Source(SALT2Source):
         m0 = self._model['M0'](phase, wave)
         m1 = self._model['M1'](phase, wave)
         tmp = trans * wave
-        f0 = np.sum(m0 * tmp, axis=1) * dwave / HC_ERG_AA
-        m1int = np.sum(m1 * tmp, axis=1) * dwave / HC_ERG_AA
+        f0 = np.sum(m0 * tmp, axis=1)/tmp.sum()
+        m1int = np.sum(m1 * tmp, axis=1)/tmp.sum()
         ftot = f0 + x1 * m1int
 
         # In the following, the "[:,0]" reduces from a 2-d array of shape
@@ -1138,7 +1139,7 @@ class SALT3Source(SALT2Source):
         lcrv11 = self._model['LCRV11'](phase, band.wave_eff)[:, 0]
         lcrv01 = self._model['LCRV01'](phase, band.wave_eff)[:, 0]
 
-        v = lcrv00 + 2.0 * x1 * lcrv01 + x1 * x1 * lcrv11
+        v = (lcrv00 + 2.0 * x1 * lcrv01 + x1 * x1 * lcrv11)
 
         # v is supposed to be variance but can go negative
         # due to interpolation.  Correct negative values to some small
@@ -1149,11 +1150,10 @@ class SALT3Source(SALT2Source):
         # avoid warnings due to evaluating 0. / 0. in f0 / ftot
         with np.errstate(invalid='ignore'):
             # new SALT3 error prescription
-            result = v/(ftot/(trans*wave*dwave).sum())/HC_ERG_AA/1e12
+            result = v/ftot**2.
 
         # treat cases where ftot is negative the same as snfit
         result[ftot <= 0.0] = 10000.
-
         return result
 
 


### PR DESCRIPTION
sorry guys, accidentally had some bugs in SALT3Source _bandflux_rvar_single that was resulting in anomalously high chi^2 values from SALT3.  These should all be fixed now.