### PR TITLE
Fix numpy build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,7 @@ requires = [
     "wheel",
     "setuptools",
     "Cython>=0.29.2",
-    "numpy==1.13.3; python_version=='3.5'",
-    "numpy==1.13.3; python_version=='3.6'",
-    "numpy==1.14.5; python_version=='3.7'",
-    "numpy==1.17.3; python_version>='3.8'",
+    "oldest-supported-numpy",
 ]
 build-backend = 'setuptools.build_meta'
 


### PR DESCRIPTION
Fix numpy build dependencies. See sncosmo/sncosmo#303. Rather than specifying specific numpy versions that will need to be updated whenever a new Python release is out, I added a dependency on the scipy oldest-supported-numpy metapackage that should keep this up to date.