### PR TITLE
Update the model documentation

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -21,8 +21,11 @@ Model & Components
    Source
    TimeSeriesSource
    StretchSource
+   MLCS2k2Source
    SALT2Source
    SALT3Source
+   SNEMOSource
+   SUGARSource
    
 *Effect components of Model: interstellar dust extinction*
 
@@ -79,7 +82,6 @@ Spectra
    Spectrum
 
 
-
 .. _fitting-api:
 
 Fitting Photometric Data
@@ -103,7 +105,6 @@ Fitting Photometric Data
    chisq
    flatten_result
 
-
 Plotting
 ========
 
@@ -113,7 +114,6 @@ Plotting
    :toctree: api
 
    plot_lc
-
 
 Simulation
 ==========

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -142,11 +142,5 @@ magnitude systems*
 Class Inheritance Diagrams
 ==========================
 
-.. inheritance-diagram:: Source TimeSeriesSource StretchSource SALT2Source SALT3Source
-   :parts: 1
-
-.. inheritance-diagram:: PropagationEffect F99Dust OD94Dust CCM89Dust
-   :parts: 1
-
-.. inheritance-diagram:: MagSystem ABMagSystem SpectralMagSystem
+.. inheritance-diagram:: models magsystems bandpasses
    :parts: 1

--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -585,12 +585,12 @@ class SUGARSource(Source):
 
     .. math::
 
-    F(t, \\lambda) = q_0 10^{-0.4 (M_0(t, \\lambda)
-                             + q_1 \alpha_1(t, \\lambda)
-                             + q_2 \alpha_2(t, \\lambda)
-                             + q_3 \alpha_3(t, \\lambda)
-                             + A_v CCM(\\lambda))}
-                             (10^{-3} c\\lambda^{2})
+        F(t, \\lambda) = q_0 10^{-0.4 (M_0(t, \\lambda)
+                                + q_1 \\alpha_1(t, \\lambda)
+                                + q_2 \\alpha_2(t, \\lambda)
+                                + q_3 \\alpha_3(t, \\lambda)
+                                + A_v CCM(\\lambda))}
+                                (10^{-3} c\\lambda^{2})
 
     where ``q_0``, ``q_1``, ``q_2``, ``q_3``,
     and ``A_v`` are the free parameters
@@ -1232,8 +1232,9 @@ class SNEMOSource(Source):
 
     .. math::
        F(t, \\lambda) = c_0(e_0(t, \\lambda) +
-                           \\Sum_{i=1}^{n} c_i e_i(t, \\lambda))
+                           \\sum_{i=1}^{n} c_i e_i(t, \\lambda))
                            \\times FM07(\\lambda, A_s)
+
     where ``c_0``, ``c_i``, and ``A_s`` are the free parameters of the model.
 
     Parameters


### PR DESCRIPTION
This addresses #299, and adds documentation for the SNEMO, SUGAR, and MLCS models.