### PR TITLE
Stop using deprecated numpy types

### DIFF
--- a/misc/gen_example_data.py
+++ b/misc/gen_example_data.py
@@ -15,7 +15,7 @@ zp = 25. * np.ones(40)
 zpsys = np.array(40 * ['ab'])
 
 flux = model.bandflux(bands, times, zp=zp, zpsys=zpsys)
-fluxerr = (0.05 * np.max(flux)) * np.ones(40, dtype=np.float)
+fluxerr = (0.05 * np.max(flux)) * np.ones(40, dtype=float)
 flux += fluxerr * np.random.randn(40)
 
 data = Table(odict([('time', times), ('band', bands), ('flux', flux),

--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -1079,7 +1079,7 @@ def nest_lc(data, model, vparam_names, bounds, guess_amplitude_bound=False,
         d = {}
         for i in range(npdim):
             d[iparam_names[i]] = ppflist[i](u[i])
-        v = np.empty(ndim, dtype=np.float)
+        v = np.empty(ndim, dtype=float)
         for i in range(ndim):
             key = vparam_names[i]
             if key in d:

--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -145,7 +145,7 @@ def _bandflux(model, band, time_or_phase, zp, zpsys):
         zpsys = np.atleast_1d(zpsys)
 
     # initialize output arrays
-    bandflux = np.zeros(time_or_phase.shape, dtype=np.float)
+    bandflux = np.zeros(time_or_phase.shape, dtype=float)
 
     # Loop over unique bands.
     for b in set(band):
@@ -182,7 +182,7 @@ def _bandmag(model, band, magsys, time_or_phase):
     magsys = magsys.ravel()
     bandflux = bandflux.ravel()
 
-    result = np.empty(bandflux.shape, dtype=np.float)
+    result = np.empty(bandflux.shape, dtype=float)
     for i, (b, ms, f) in enumerate(zip(band, magsys, bandflux)):
         ms = get_magsystem(ms)
         zpf = ms.zpbandflux(b)
@@ -1323,7 +1323,7 @@ class Model(_ModelBase):
         # Set parameter names, initial values (inital values set to zero)
         self._param_names = ['z', 't0']
         self.param_names_latex = ['z', 't_0']
-        self._parameters = np.zeros(2, dtype=np.float)
+        self._parameters = np.zeros(2, dtype=float)
 
         # Set source and add source parameter names
         self._source = get_source(source, copy=True)
@@ -1437,7 +1437,7 @@ class Model(_ModelBase):
 
         # allocate new array (zeros so that new 'free' effects redshifts
         # initialize to 0)
-        self._parameters = np.zeros(l, dtype=np.float)
+        self._parameters = np.zeros(l, dtype=float)
 
         # copy old parameters: we do this to make sure we copy
         # non-default values of any parameters that the model alone
@@ -1628,7 +1628,7 @@ class Model(_ModelBase):
         ndim = (band.ndim, z.ndim)
         band = band.ravel()
         z = z.ravel()
-        overlap = np.empty((len(band), len(z)), dtype=np.bool)
+        overlap = np.empty((len(band), len(z)), dtype=bool)
         shift = (1. + z)/(1+self._parameters[0])
         for i, b in enumerate(band):
             b = get_bandpass(b)

--- a/sncosmo/photdata.py
+++ b/sncosmo/photdata.py
@@ -65,7 +65,7 @@ class PhotometricData(object):
         # if the original array already contains all bandpass objects,
         # but constructing a new array is simpler.)
         band_orig = data[mapping['band']]
-        self.band = np.empty(len(band_orig), dtype=np.object)
+        self.band = np.empty(len(band_orig), dtype=object)
         for i in range(len(band_orig)):
             self.band[i] = get_bandpass(band_orig[i])
 
@@ -145,7 +145,7 @@ class PhotometricData(object):
         the given zeropoint and zeropoint system."""
 
         normmagsys = get_magsystem(zpsys)
-        factor = np.empty(len(self), dtype=np.float)
+        factor = np.empty(len(self), dtype=float)
 
         for b in set(self.band.tolist()):
             mask = self.band == b

--- a/sncosmo/plotting.py
+++ b/sncosmo/plotting.py
@@ -226,7 +226,7 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab',
     # filled: used only if data is not None. Guarantee array of booleans
     if data is not None:
         if fill_data_marker is None:
-            fill_data_marker = np.ones(data.time.shape, dtype=np.bool)
+            fill_data_marker = np.ones(data.time.shape, dtype=bool)
         else:
             fill_data_marker = np.asarray(fill_data_marker)
             if fill_data_marker.shape != data.time.shape:

--- a/sncosmo/tests/test_models.py
+++ b/sncosmo/tests/test_models.py
@@ -14,7 +14,7 @@ def flatsource():
     all times."""
     phase = np.linspace(0., 100., 10)
     wave = np.linspace(800., 20000., 100)
-    flux = np.ones((len(phase), len(wave)), dtype=np.float)
+    flux = np.ones((len(phase), len(wave)), dtype=float)
     return sncosmo.TimeSeriesSource(phase, wave, flux)
 
 

--- a/sncosmo/tests/test_plotting.py
+++ b/sncosmo/tests/test_plotting.py
@@ -18,7 +18,7 @@ class TestPlotLC:
         # Create a TimeSeriesSource with a flat spectrum at all times.
         phase = np.linspace(0., 100., 10)
         wave = np.linspace(1000., 10000., 100)
-        flux = np.ones((len(phase), len(wave)), dtype=np.float)
+        flux = np.ones((len(phase), len(wave)), dtype=float)
         source = sncosmo.TimeSeriesSource(phase, wave, flux)
         self.model = sncosmo.Model(source=source)
 


### PR DESCRIPTION
Numpy deprecated all of the type aliases that just referred to Python types in version 1.20.0. See numpy/numpy#14882 This PR replaces every use of one of those types with the identical Python type.

This fixes #310