### PR TITLE
Remove MCMC test that can fail stochastically

### DIFF
--- a/sncosmo/tests/test_fitting.py
+++ b/sncosmo/tests/test_fitting.py
@@ -163,17 +163,6 @@ class TestFitting:
         assert_allclose(fitmodel.parameters, self.model.parameters, rtol=0.05)
 
     @pytest.mark.skipif('not HAS_EMCEE')
-    def test_mcmc_lc(self):
-        """Ensure that mcmc runs."""
-        self.model.set(**self.params)
-
-        res, fitmodel = sncosmo.mcmc_lc(self.data, self.model,
-                                        ['amplitude', 'z', 't0'],
-                                        bounds={'z': (0., 1.0)})
-
-        assert_allclose(fitmodel.parameters, self.model.parameters, rtol=0.05)
-
-    @pytest.mark.skipif('not HAS_EMCEE')
     def test_mcmc_invalid_sampler(self):
         """Ensure that mcmc runs."""
         with pytest.raises(ValueError):


### PR DESCRIPTION
I added a test for emcee that failed stochastically on one of the latest builds. I thought that it would be stable because we start it at the solution and give it a wide range of leeway in the comparison, but apparently not. There isn't a great way to test this in a non-stochastic way. For now, we have a test that makes sure that emcee runs without any errors and that's probably good enough.

This is a problem with the testing, and doesn't affect the actual v2.6.0 code in any way.