### PR TITLE
Update codecov configuration to ignore non-project files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,6 @@
 comment: off
+
+ignore:
+  - "sncosmo/tests/*"
+  - "sncosmo/conftest.py"
+  - "sncosmo/__init__.py"


### PR DESCRIPTION
The codecov configuration that we are using counts all of the tests and configuration files in its coverage. This was not intended, and these were ignored with the previous code coverage tool. This PR tells codecov to ignore those files.

Note that this will cause the overall coverage to go down because the tests themselves have near perfect coverage.