### PR TITLE
Update codecov.io uploader version

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -70,6 +70,6 @@ jobs:
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }}
     - name: Upload coverage to codecov
       if: contains(matrix.toxenv,'-cov')
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml


### PR DESCRIPTION
I got an email that codecov.io has deprecated the uploader that we are using. See https://github.com/codecov/codecov-action for details. This PR changes our github action to use the new version.