### PR TITLE
Mark one more test that needs to download data

### DIFF
--- a/sncosmo/tests/test_spectrum.py
+++ b/sncosmo/tests/test_spectrum.py
@@ -42,6 +42,7 @@ def test_bin_edges_log():
     assert_allclose(wave, spec.wave, rtol=1.e-5)
 
 
+@pytest.mark.might_download
 class TestSpectrum:
     def setup_class(self):
         # Simulate a spectrum


### PR DESCRIPTION
I am currently working to [package sncosmo for Debian](https://bugs.debian.org/757096). The build on Debian is done without internet connection; this includes the test that is done at build time to ensure the package works properly.
While testing this, I discovered another group of tests that require remote connection; this is fixed with this PR.

Since sncosmos is an Astropy affiliated package: maybe it may be worth to switch to the use of the [pytest-remotedata](https://pypi.org/project/pytest-remotedata/) package instead?