### PR TITLE
Use assert_allclose for comparison in test_salt2colorlaw_vs_python

### DIFF
--- a/sncosmo/tests/test_salt2utils.py
+++ b/sncosmo/tests/test_salt2utils.py
@@ -104,7 +104,7 @@ def test_salt2colorlaw_vs_python():
     colorlaw = SALT2ColorLaw(colorlaw_range, colorlaw_coeffs)
 
     wave = np.linspace(2000., 9200., 201)
-    assert np.all(colorlaw(wave) == colorlaw_python(wave))
+    np.testing.assert_allclose(colorlaw(wave), colorlaw_python(wave))
 
 
 def test_salt2colorlaw_pickle():


### PR DESCRIPTION
On Debian, the package is built and tested on several platforms with different CPU architectures.

On some architectures (i386, arm64, ppc64, riscv64), [one test fails](https://buildd.debian.org/status/fetch.php?pkg=sncosmo&arch=arm64&ver=2.8.0-1&stamp=1660665749&raw=0) because it compares two arrays computed in different ways to be equal. The assert fails here, since on these platforms the result is slightly (negligible) different.

The PR replaces the "=" assert with np.testing.assert_allclose, which allows small deviations. This [fixes this failure](https://buildd.debian.org/status/fetch.php?pkg=sncosmo&arch=arm64&ver=2.8.0-2&stamp=1660686860&raw=0).