### PR TITLE
Update on the DATAMIRROR, using secure http now

### DIFF
--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -57,7 +57,7 @@ def get_rootdir():
     return data_dir
 
 
-DATADIR = DataMirror(get_rootdir, "http://sncosmo.github.io/data")
+DATADIR = DataMirror(get_rootdir, "https://sncosmo.github.io/data")
 
 
 # =============================================================================


### PR DESCRIPTION
I had the issue that a new laptop, new fresh install, won't download the models using this data mirror just because of the http instead of https in the url.

Didn't want to open an issue for such a minor change. 