### PR TITLE
Salt2 ColorLaw function correction

### DIFF
--- a/sncosmo/salt2utils.pyx
+++ b/sncosmo/salt2utils.pyx
@@ -482,6 +482,6 @@ cdef class SALT2ColorLaw(object):
         # reconstruct input wavelengths
         wave_lo = self.l_lo * SALT2CL_V_MINUS_B + SALT2CL_B
         wave_hi = self.l_hi * SALT2CL_V_MINUS_B + SALT2CL_B
-        coeffs = [self.coeffs[i+1] for i in range(self.ncoeffs)]
+        coeffs = [self.coeffs[i+1] for i in range(self.ncoeffs - 1)]
 
         return (wave_lo, wave_hi), coeffs

--- a/sncosmo/tests/test_salt2utils.py
+++ b/sncosmo/tests/test_salt2utils.py
@@ -109,7 +109,7 @@ def test_salt2colorlaw_vs_python():
 
 def test_salt2colorlaw_pickle():
 
-    colorlaw_coeffs = [-0.504294, 0.787691, -0.461715, 0.0815619]
+    colorlaw_coeffs = [-0.504294, 0.787691, -0.461715, 0.0815619, 0.0, 0.0]
     colorlaw_range = (2800., 7000.)
     colorlaw = SALT2ColorLaw(colorlaw_range, colorlaw_coeffs)
 


### PR DESCRIPTION
Hi, an error has been found when Pickling/Unpickling objects than contain sncosmo.models _Model_ objects : it updates the _SALT2ColorLaw_ object coefficients (in salt2utils.pyx) and then crash. 

It is due to the function _\_\_get_new_args\_\__ that has been made for pickling,  and that adds an extra value in the coefficients array to return.
I show an illustration of the bug in the picture below, we begin with some coefficients for the colorlaw and then it add 0s. 

I replaced **ncoeffs**, that is be the number of input coefficients +1,  to **ncoeffs-1** in the _\_\_get_new_args\_\__ function.

![bug_colorlaw](https://github.com/sncosmo/sncosmo/assets/126498726/34eab1eb-6ebb-43da-a7c6-fe314aa93590)

