### PR TITLE
Fix chisq function returning nan which crashes iminuit

### DIFF
--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -59,6 +59,8 @@ def generate_chisq(data, model, spectra, signature='iminuit', modelcov=False):
                                             zp=data.zp, zpsys=data.zpsys)
                 diff = data.flux - model_flux
                 phot_chisq = np.dot(np.dot(diff, invcov), diff)
+                if math.isnan(phot_chisq):
+                    phot_chisq = float('inf') # Tell iminuit to keep away from this point (in most cases this should be inf instead of nan anyway)
                 full_chisq += phot_chisq
 
             if spectra is not None:


### PR DESCRIPTION
This works for me and has not negatively affected the validity of the result of the maximisation.
Please fix the issue of `chisq` returning NaN this way or another

The issue happens because of infinite flux in the model and the invcov matrix is diagonal, so $∞⋅0=$`NaN`