### PR TITLE
Make tests warnings-clean

### DIFF
--- a/docs/_helpers/bandpass_plot.py
+++ b/docs/_helpers/bandpass_plot.py
@@ -3,10 +3,9 @@
 import numpy as np
 from matplotlib import rc
 from matplotlib import pyplot as plt
-from matplotlib.cm import get_cmap
 import sncosmo
 
-cmap = get_cmap('viridis')
+cmap = plt.get_cmap('viridis')
 
 def plot_bandpass_set(setname):
     """Plot the given set of bandpasses."""

--- a/docs/_logo/make_logo.py
+++ b/docs/_logo/make_logo.py
@@ -5,7 +5,7 @@ from matplotlib import cm
 import matplotlib.pyplot as plt
 import sncosmo
 
-cmap = cm.get_cmap('gist_rainbow')
+cmap = plt.get_cmap('gist_rainbow')
 model = sncosmo.get_source('hsiao')
 
 wave = model._wave

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ build-backend = 'setuptools.build_meta'
 markers = [
     "might_download: marks tests that might download a file",
 ]
+filterwarnings = [
+    "error",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,5 @@ markers = [
 ]
 filterwarnings = [
     "error",
+    "always::astropy.wcs.FITSFixedWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,6 @@ markers = [
 ]
 filterwarnings = [
     "error",
+    "always:numpy.ndarray size changed:RuntimeWarning",
     "always::astropy.wcs.FITSFixedWarning",
 ]

--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -421,7 +421,6 @@ def _run_iminuit(chisq, parameter_names, start_values, start_errors, bounds,
 
         for key in fixed_parameters:
             m.fixed[key] = True
-            m.errors[key] = 0.
 
         m.migrad(ncall=maxcall)
         fmin = m.fmin

--- a/sncosmo/fitting.py
+++ b/sncosmo/fitting.py
@@ -396,11 +396,7 @@ def _run_iminuit(chisq, parameter_names, start_values, start_errors, bounds,
 
     # The iminuit API changed significantly in version 2. Handle both the new
     # and old APIs.
-    try:
-        from distutils.version import LooseVersion
-    except ModuleNotFoundError:
-        # distutils was dropped in python 2.12
-        from looseversion import LooseVersion
+    from looseversion import LooseVersion
     iminuit_version = LooseVersion(iminuit.__version__)
 
     if verbose:

--- a/sncosmo/plotting.py
+++ b/sncosmo/plotting.py
@@ -200,7 +200,7 @@ def plot_lc(data=None, model=None, bands=None, zp=25., zpsys='ab',
     # Color options.
     if color is None:
         if cmap is None:
-            cmap = cm.get_cmap('jet_r')
+            cmap = plt.get_cmap('jet_r')
 
     # Standardize and normalize data.
     if data is not None:

--- a/sncosmo/specmodel.py
+++ b/sncosmo/specmodel.py
@@ -43,7 +43,7 @@ class SpectrumModel(object):
         # internally, flux is in F_lambda:
         if unit != FLAMBDA_UNIT:
             self.flux = unit.to(FLAMBDA_UNIT, self.flux,
-                                u.spectral_density(u.AA, self.wave))
+                                u.spectral_density(self.wave * u.AA))
         self._unit = FLAMBDA_UNIT
 
         # Set up interpolation.

--- a/sncosmo/tests/test_download_builtins.py
+++ b/sncosmo/tests/test_download_builtins.py
@@ -22,13 +22,30 @@ magsystems = [i['name'] for i in _MAGSYSTEMS.get_loaders_metadata()]
 sources = [(i['name'], i['version']) for i in _SOURCES.get_loaders_metadata()]
 
 
+@pytest.fixture
+def all_tarfile_errors_are_fatal():
+    """
+    Raise tarfile.FilterError to caller (raised if tarfile.data_filter actually
+    filters out any archive members)
+    """
+    import tarfile
+    errorlevel = tarfile.TarFile.errorlevel
+    try:
+        tarfile.TarFile.errorlevel = 2
+        yield
+    finally:
+        tarfile.TarFile.errorlevel = errorlevel
+
+
 @pytest.mark.might_download
+@pytest.mark.usefixtures("all_tarfile_errors_are_fatal")
 @pytest.mark.parametrize("name", bandpasses)
 def test_builtin_bandpass(name):
     sncosmo.get_bandpass(name)
 
 
 @pytest.mark.might_download
+@pytest.mark.usefixtures("all_tarfile_errors_are_fatal")
 @pytest.mark.parametrize("name", bandpass_interpolators)
 def test_builtin_bandpass_interpolator(name):
     interpolator = _BANDPASS_INTERPOLATORS.retrieve(name)
@@ -36,12 +53,14 @@ def test_builtin_bandpass_interpolator(name):
 
 
 @pytest.mark.might_download
+@pytest.mark.usefixtures("all_tarfile_errors_are_fatal")
 @pytest.mark.parametrize("name,version", sources)
 def test_builtin_source(name, version):
     sncosmo.get_source(name, version)
 
 
 @pytest.mark.might_download
+@pytest.mark.usefixtures("all_tarfile_errors_are_fatal")
 @pytest.mark.parametrize("name", magsystems)
 def test_builtin_magsystem(name):
     sncosmo.get_magsystem(name)

--- a/sncosmo/tests/test_models.py
+++ b/sncosmo/tests/test_models.py
@@ -366,7 +366,7 @@ def test_effect_phase_dependent():
                                                                 [10., 10.])],
                                 effect_frames=['rest'],
                                 effect_names=['micro'])
-    assert_approx_equal(model_micro.flux(50., 5000.).flatten(), flux*10.)
+    assert_allclose(model_micro.flux(50., 5000.).flatten(), flux*10.)
 
 
 def test_G10():

--- a/sncosmo/utils.py
+++ b/sncosmo/utils.py
@@ -352,6 +352,10 @@ def download_dir(remote_url, dirname):
 
     # create a tarfile with the buffer and extract
     tf = tarfile.open(fileobj=buf, mode=mode)
+    # use data_filter if available (py3.12+)
+    tf.extraction_filter = getattr(
+        tarfile, 'data_filter', (lambda member, path: member)
+    )
     tf.extractall(path=dirname)
     tf.close()
     buf.close()  # buf not closed when tf is closed.


### PR DESCRIPTION
Deprecation warnings are annoying, but addressing them can prevent nasty surprises when the announced changes arrive. Take these seriously by treating them as hard errors during tests.

Along the way, squash the deprecation warnings that currently pop up in tests:
- Scalar comparison of single-element numpy arrays
- Two-argument `astropy.units.spectral_density()`
- `TarFile.extract_all()` with no filter
- importing `distutils`
- `matplotlib.cm.get_cmap()`
- Setting initial error estimate to 0 for fixed parameters in iminuit (not a deprecation warning, but never did anything except raise a warning)

Astropy FITS header upgrade warnings are kept as warnings, as silencing them would require changing the underlying FITS file.